### PR TITLE
Update README to use symbols instead of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ client.create_token('bob-1')
 
 ```ruby
 client.update_user({
-    'id' => 'bob-1',
-    'role' => 'admin',
-    'name' => 'Robert Tables'
+    :id => 'bob-1',
+    :role => 'admin',
+    :name => 'Robert Tables'
 })
 
 # batch update is also supported


### PR DESCRIPTION
This fixes the specific issue in #11, but there seems to be a lot of inconsistencies here.

Like this one which uses strings.
```
    def create_channel_type(data)
      if !data.key? "commands" || data["commands"].nil? || data["commands"].empty?
        data["commands"] = ["all"]
      end
      post("channeltypes", data: data)
    end
```

Easiest fix is to switch to using rails' `HashWithIndifferentAccess` [see here](https://rubyquicktips.com/post/603292403/accessing-a-hash-with-either-string-or-symbol-keys). Although that requires a big import. If we want to avoid that path and just fix the code itself I can't say I'm experienced enough in ruby to know the best way (adding support for both, switching all to one way, or what).