### PR TITLE
Fix raise syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ See [an example rails application using the Ruby SDK](https://github.com/GetStre
 First, make sure you can run the test suite. Tests are run via rspec
 
 ```bash
-STREAM_KEY=my_api_key STREAM_SECRET=my_api_secret bundle exec rake spec
+STREAM_CHAT_API_KEY=my_api_key STREAM_CHAT_API_SECRET=my_api_secret bundle exec rake spec
 ```
 
 ### Releasing a new version

--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -93,7 +93,7 @@ module StreamChat
       payload = {}
       users.each do |user|
         id = user[:id] || user["id"]
-        raise ArgumentError "user must have an id" unless id
+        raise ArgumentError, "user must have an id" unless id
         payload[id] = user
       end
       post('users', data: {'users': payload})

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -70,6 +70,11 @@ describe StreamChat::Client do
     expect(response['users']).to include users[0][:id]
   end
 
+  it 'raises when a user without an id is provided' do
+    users = [{}, {}]
+    expect {@client.update_users(users)}.to raise_error(ArgumentError)
+  end
+
   it 'makes partial user update' do
     user_id = SecureRandom.uuid
     @client.update_user({id: user_id, field: 'value'})


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

When passing `update_users` with a user that does not have an id set, an ArgumentError should be raised indicating that an id was missing.  But instead, `undefined method 'ArgumentError'` was raised due to a missing comma.  I added the comma. 

Also, the README provides instructions to set env variables in order to run specs, but those variables do not match the ones used in the specs.  I updated the README to use the correct variables.