### PR TITLE
Allow end-users to see the error code, for fine grained exception handling

### DIFF
--- a/lib/stream-chat/errors.rb
+++ b/lib/stream-chat/errors.rb
@@ -2,7 +2,8 @@
 
 module StreamChat
   class StreamAPIException < StandardError
-    
+    attr_reader :error_code
+
     def initialize(response)
       @response = response
       p response


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Now endusers can check error_code. Do you want a test for this?