### PR TITLE
Drop unsupported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 before_install:
   - gem update bundler
 rvm:
-  - 2.3
-  - 2.4
   - 2.5
   - 2.6
   - 2.7


### PR DESCRIPTION
2.3 and 2.4 are EOL.