### PR TITLE
added check sqs endpoint to sdk

### DIFF
--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -303,6 +303,10 @@ module StreamChat
       parse_response(response)
     end
 
+    def check_sqs(sqs_key = nil, sqs_secret = nil, sqs_url = nil)
+      post('check_sqs', data: { "sqs_key": sqs_key, "sqs_secret": sqs_secret, "sqs_url": sqs_url })
+    end
+
     private
 
     def get_default_params

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -309,4 +309,10 @@ describe StreamChat::Client do
       /cannot delete the builtin block list/
     )
   end
+
+  it 'check_sqs with an invalid queue url should fail' do
+    resp = @client.check_sqs('key', 'secret', 'https://foo.com/bar')
+    expect(resp['status']).to eq 'error'
+    expect(resp['error']).to include 'invalid SQS url'
+  end
 end


### PR DESCRIPTION
added sync and async endpoint for `check_sqs`, an endpoint to be used to verify credentials/settings for SQS push.

🚨  This depends on a (currently) unreleased backend feature, hence the failing tests. To be merged afterward.

related python SDK changes: https://github.com/GetStream/stream-chat-python/pull/50