### PR TITLE
support GetRateLimits endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ status_response = client.get_export_channel_status(response['task_id'])
 # status_response['status'] == 'pending', 'completed'
 ```
 
+### Rate limits
+```ruby
+# Get all rate limits
+limits = client.get_rate_limits
+
+# Get rate limits for specific platform(s)
+limits = client.get_rate_limits(server_side: true)
+
+# Get rate limits for specific platforms and endpoints
+limits = client.get_rate_limits(android: true, ios: true, endpoints: ['QueryChannels', 'SendMessage'])
+```
+
 ### Example Rails application
 
 See [an example rails application using the Ruby SDK](https://github.com/GetStream/rails-chat-example).

--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -232,6 +232,17 @@ module StreamChat
       get('devices', params: { user_id: user_id })
     end
 
+    def get_rate_limits(server_side: false, android: false, ios: false, web: false, endpoints: [])
+      params = {}
+      params['server_side'] = server_side if server_side
+      params['android'] = android if android
+      params['ios'] = ios if ios
+      params['web'] = web if web
+      params['endpoints'] = endpoints.join(",") if endpoints.length > 0
+
+      get('rate_limits', params: params)
+    end
+
     def verify_webhook(request_body, x_signature)
       signature = OpenSSL::HMAC.hexdigest('SHA256', @api_secret, request_body)
       signature == x_signature

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -211,6 +211,36 @@ describe StreamChat::Client do
     expect(response['devices'].length).to eq 1
   end
 
+  describe 'get rate limits' do
+    it 'lists all limits' do
+      response = @client.get_rate_limits
+      expect(response['android']).not_to be_nil
+      expect(response['ios']).not_to be_nil
+      expect(response['web']).not_to be_nil
+      expect(response['server_side']).not_to be_nil
+    end
+
+    it 'lists limits for a single platform' do
+      response = @client.get_rate_limits(server_side: true)
+      expect(response['server_side']).not_to be_nil
+      expect(response['android']).to be_nil
+      expect(response['ios']).to be_nil
+      expect(response['web']).to be_nil
+    end
+
+    it 'lists limits for a few endpoints' do
+      response = @client.get_rate_limits(server_side: true, android: true, endpoints: ['GetRateLimits', 'QueryChannels'])
+      expect(response['ios']).to be_nil
+      expect(response['web']).to be_nil
+      expect(response['android']).not_to be_nil
+      expect(response['android'].length).to eq(2)
+      expect(response['android']['GetRateLimits']['limit']).to eq(response['android']['GetRateLimits']['remaining'])
+      expect(response['server_side']).not_to be_nil
+      expect(response['server_side'].length).to eq(2)
+      expect(response['server_side']['GetRateLimits']['limit']).to be > response['server_side']['GetRateLimits']['remaining']
+    end
+  end
+
   it 'search for messages' do
     text = SecureRandom.uuid
     @channel.send_message({ text: text }, 'legolas')


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

This PR adds support for the GetRateLimits endpoint to retrieve rate limit quotas and usage.

## Changelog

```
## March 9, 2021
- Add get_rate_limits endpoint
```