### PR TITLE
Fix load faraday/mutipart error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ group :dev do
 end
 
 group :test do
-  gem 'faraday'
-  gem 'faraday-multipart'
   gem 'rack'
   gem 'simplecov'
 end

--- a/stream-chat.gemspec
+++ b/stream-chat.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>=2.5.0'
 
   gem.add_dependency 'faraday'
+  gem.add_dependency 'faraday-multipart'
   gem.add_dependency 'jwt'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
# Submit a pull request
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

In gemspec, the version of faraday is not locked, so when I added the gem, the latest faraday was installed and LoadError faraday/multipart was raised.

![image](https://user-images.githubusercontent.com/3257272/149616828-c50572a5-4497-4312-9819-141fdabe0421.png)


https://github.com/lostisland/faraday/blob/9825916400379e4dc1bf8616a57b53f5200958bd/UPGRADING.md#so-what-should-i-do-if-i-currently-use-the-retry-or-multipart-middleware
