### PR TITLE
Fix example Client instantiation in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ gem install stream-chat-ruby
 ```ruby
 require 'stream-chat'
 
-client = StreamChat::Client.new(api_key='STREAM_KEY', api_secret='STREAM_SECRET')
+client = StreamChat::Client.new('STREAM_KEY', 'STREAM_SECRET')
 ```
 
 > 💡 Note: since v2.21.0 we implemented [Sorbet](https://sorbet.org/) type checker. As of v2.x.x we only use it for static type checks and you won't notice any difference, but from v3.0.0 **we will enable runtime checks** 🚨 🚨 🚨.


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

The readme contains an example of how to create an instance of `StreamChat::Client`. This contains local variable assignment. It might have been a copy+paste of [Python client](https://github.com/GetStream/stream-chat-python#-getting-started) where I believe that is the correct syntax for a method call.

The initializer is defined as:

```ruby
    def initialize(api_key, api_secret, timeout = nil, **options)
```

Since this method doesn't accept keyword arguments, changing this to use named arguments would cause a runtime error. So the correct way to call this method is with two positional arguments.