### PR TITLE
upgrade: faraday to 2.0.1

### DIFF
--- a/stream-chat.gemspec
+++ b/stream-chat.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |gem|
     'source_code_uri' => 'https://github.com/GetStream/stream-chat-ruby'
   }
 
-  gem.add_dependency 'faraday', '~> 1.10.0'
-  gem.add_dependency 'faraday-multipart', '~> 1.0.3'
-  gem.add_dependency 'faraday-net_http_persistent', '~> 1.2'
+  gem.add_dependency 'faraday', '~> 2.0.1'
+  gem.add_dependency 'faraday-multipart', '~> 1.0.4'
+  gem.add_dependency 'faraday-net_http_persistent', '~> 2.0.1'
   gem.add_dependency 'jwt', '~> 2.3'
   gem.add_dependency 'net-http-persistent', '~> 4.0'
   gem.add_dependency 'sorbet-runtime', '~> 0.5.10539'


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

There is an out-dated dependency to Faraday 1.10.
In this PR, I upgrade Faraday to a more recent version 2.0.1 (Faraday's maintainers explicitly asked to avoid 2.0.0).

Almost all tests are good
113 examples, 4 failures, 4 pending, 1 error occurred outside of examples
rspec ./spec/channel_spec.rb:226 # StreamChat::Channel send message with pending metadata
rspec ./spec/channel_spec.rb:239 # StreamChat::Channel hides\shows channel for user
rspec ./spec/client_spec.rb:369 # StreamChat::Client handles devices
rspec ./spec/client_spec.rb:741 # StreamChat::Client campaigns full flow

The reasons of failure seem not be linked to the upgrade.

### Failures
**StreamChat::Channel send message with pending metadata**
```
Failure/Error: raise StreamAPIException, response if response.status >= 399

StreamChat::StreamAPIException:
StreamChat error code 17: SendMessage failed with error: "pending messages not enabled for this app"
```

**StreamChat::Channel hides\shows channel for user**
```
Failure/Error: raise StreamAPIException, response if response.status >= 399

StreamChat::StreamAPIException:
StreamChat error code 4: HideChannel failed with error: "User with ID 4e76473d-7f42-4182-bb01-db19900f7239 is not channel member"
```
**StreamChat::Client handles devices**
```
Failure/Error: raise StreamAPIException, response if response.status >= 399

StreamChat::StreamAPIException:
StreamChat error code 4: CreateDevice failed with error: "push provider "" with type "apn" not found"
```

**StreamChat::Client campaigns full flow**
```
Failure/Error: raise StreamAPIException, response if response.status >= 399

StreamChat::StreamAPIException:
 StreamChat error code 17: CreateSegment failed with error: "this endpoint needs a feature flag, contact support to get it enabled"
```


