### PR TITLE
upgrade faraday to 2.12.2

### DIFF
--- a/stream-chat.gemspec
+++ b/stream-chat.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |gem|
     'source_code_uri' => 'https://github.com/GetStream/stream-chat-ruby'
   }
 
-  gem.add_dependency 'faraday', '~> 2.0.1'
-  gem.add_dependency 'faraday-multipart', '~> 1.0.4'
-  gem.add_dependency 'faraday-net_http_persistent', '~> 2.0.1'
+  gem.add_dependency 'faraday', '~> 2.12.2'
+  gem.add_dependency 'faraday-multipart', '~> 1.1.0'
+  gem.add_dependency 'faraday-net_http_persistent', '~> 2.3.0'
   gem.add_dependency 'jwt', '~> 2.3'
   gem.add_dependency 'net-http-persistent', '~> 4.0'
   gem.add_dependency 'sorbet-runtime', '~> 0.5.10539'


### PR DESCRIPTION
# Submit a pull request

Upgrade faraday dependency to the latest (2.12.2) version

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

Ran tests, failed ones don't seem to be related to faraday changes

## Description of the pull request

Upgrading faraday gem dependency version to the latest as current was created 3 years ago.
