### PR TITLE
[] Added Prism TO sorbet todo

### DIFF
--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -8,3 +8,4 @@ module T::CompatibilityPatches::RSpecCompatibility::MethodDoubleExtensions; end
 module T::CompatibilityPatches::RSpecCompatibility::RecorderExtensions; end
 module T::Private::Methods::MethodHooks; end
 module T::Private::Methods::SingletonMethodHooks; end
+class Prism::LexCompat::Result; end


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Fix Sorbet type checking issue in Ruby 3.4 by adding missing RBI definition for `Prism::LexCompat::Result` [ it will skip the sorbet type check for this package ]

Tested against Ruby 3.0, 3.1, and 3.4 - all passing type checks now.
https://github.com/GetStream/stream-chat-ruby/actions/runs/14107089578/job/39516030327