### PR TITLE
[MOD-531]: check_user_profile support for Ruby SDK

### DIFF
--- a/lib/stream-chat/moderation.rb
+++ b/lib/stream-chat/moderation.rb
@@ -15,7 +15,7 @@ module StreamChat
       {
         user: 'stream:user',
         message: 'stream:chat:v1:message',
-        userprofile: 'stream:v1:user_profile',
+        userprofile: 'stream:v1:user_profile'
       }.freeze,
       T::Hash[Symbol, String]
     )
@@ -38,6 +38,9 @@ module StreamChat
     # @option profile [String] :username Username to be checked
     # @option profile [String] :image Image URL to be checked
     # @return [StreamChat::StreamResponse]
+    #
+    # example:
+    # client.moderation.check_user_profile('user-id', {username: 'bad_username', image: 'https://example.com/profile.jpg'})
     sig do
       params(
         user_id: String,

--- a/lib/stream-chat/moderation.rb
+++ b/lib/stream-chat/moderation.rb
@@ -14,7 +14,8 @@ module StreamChat
     MODERATION_ENTITY_TYPES = T.let(
       {
         user: 'stream:user',
-        message: 'stream:chat:v1:message'
+        message: 'stream:chat:v1:message',
+        userprofile: 'stream:v1:user_profile',
       }.freeze,
       T::Hash[Symbol, String]
     )

--- a/lib/stream-chat/moderation.rb
+++ b/lib/stream-chat/moderation.rb
@@ -25,6 +25,45 @@ module StreamChat
       @client = client
     end
 
+    # Experimental: Check user profile
+    #
+    # Warning: This is an experimental feature and the API is subject to change.
+    #
+    # This function is used to check a user profile for moderation.
+    # This will not create any review queue items for the user profile.
+    # You can just use this to check whether to allow a certain user profile to be created or not.
+    #
+    # @param [string] user_id User ID to be checked
+    # @param [Hash] profile Profile data to be checked
+    # @option profile [String] :username Username to be checked
+    # @option profile [String] :image Image URL to be checked
+    # @return [StreamChat::StreamResponse]
+    sig do
+      params(
+        user_id: String,
+        profile: T::Hash[Symbol, T.nilable(String)]
+      ).returns(StreamChat::StreamResponse)
+    end
+    def check_user_profile(user_id, profile)
+      raise ArgumentError, 'Either username or image must be provided' if profile[:username].nil? && profile[:image].nil?
+
+      moderation_payload = {}
+      moderation_payload[:texts] = [profile[:username]] if profile[:username]
+      moderation_payload[:images] = [profile[:image]] if profile[:image]
+
+      check(
+        T.must(MODERATION_ENTITY_TYPES[:userprofile]),
+        user_id,
+        moderation_payload,
+        'user_profile:default',
+        entity_creator_id: user_id,
+        options: {
+          force_sync: true,
+          test_mode: true
+        }
+      )
+    end
+
     # Flags a user with a reason
     #
     # @param [string] flagged_user_id User ID to be flagged

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -159,6 +159,24 @@ describe StreamChat::Moderation do
       expect(response['duration']).not_to be_nil
     end
 
+    it 'check user profile' do
+      response = @moderation.check_user_profile(
+        @test_user_id,
+        { username: 'fuck_you_123' }
+      )
+      expect(response['duration']).not_to be_nil
+      expect(response['status']).to eq('complete')
+      expect(response['recommended_action']).to eq('remove')
+
+      response = @moderation.check_user_profile(
+        @test_user_id,
+        { username: 'hi' }
+      )
+      expect(response['duration']).not_to be_nil
+      expect(response['status']).to eq('complete')
+      expect(response['recommended_action']).to eq('keep')
+    end
+
     it 'config test' do
       # Create moderation config
       moderation_config = {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Context: https://getstream.io/moderation/docs/guides/moderate-username-and-images/

Ruby SDK was missing support for Moderating Usernames and Images. This PR adds the support for that.

Usage:

```
client.moderation.check_user_profile('user-id', {username: 'bad_username'})
client.moderation.check_user_profile('user-id', {image: 'https://example.com/profile.jpg'})
client.moderation.check_user_profile('user-id', {username: 'bad_username', image: 'https://example.com/profile.jpg'})
```
