### PR TITLE
[CHA-950] added message undelete api for ruby

### DIFF
--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -419,6 +419,13 @@ module StreamChat
       delete("messages/#{message_id}", params: options)
     end
 
+    # Un-deletes a message.
+    sig { params(message_id: String, undeleted_by: String, options: T.untyped).returns(StreamChat::StreamResponse) }
+    def undelete_message(message_id, undeleted_by, **options)
+      payload = { undeleted_by: undeleted_by }.merge(options)
+      post("messages/#{message_id}/undelete", data: payload)
+    end
+
     # Queries banned users.
     #
     # Banned users can be retrieved in different ways:

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -411,6 +411,28 @@ describe StreamChat::Client do
     @client.delete_message(msg_id, hard: true)
   end
 
+  it 'undeletes a message' do
+    msg_id = SecureRandom.uuid
+    user_id = @random_user[:id]
+    @channel.send_message({
+                            'id' => msg_id,
+                            'text' => 'to be deleted and restored'
+                          }, user_id)
+    # soft delete
+    @client.delete_message(msg_id)
+
+    # check it is deleted
+    response = @client.get_message(msg_id, show_deleted_message: true)
+    expect(response['message']['deleted_at']).not_to be_nil
+
+    # now undelete
+    @client.undelete_message(msg_id, user_id)
+
+    # now we should be able to get it without an error and without the flag
+    response = @client.get_message(msg_id)
+    expect(response['message']['deleted_at']).to be_nil
+  end
+
   it 'query banned users' do
     @client.ban_user(@random_user[:id], user_id: @random_users[0][:id], reason: 'rubytest')
     response = @client.query_banned_users({ 'reason' => 'rubytest' }, limit: 1)


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This adds the message undelete endpoint to the SDK with its test-cases. 