### PR TITLE
isloated tests

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -32,10 +32,10 @@ describe StreamChat::Client do
       { id: 'legolas', name: 'Legolas', race: 'Elf', age: 500 }
     ]
     @client.upsert_users(@fellowship_of_the_ring)
-    
+
     # Create a new channel for chat max length for channel_id is 64 characters
     channel_id = 'fellowship-of-the-ring-chat-' + SecureRandom.alphanumeric(20)
-    
+
     @channel = @client.channel('team', channel_id: channel_id,
                                        data: { members: @fellowship_of_the_ring.map { |fellow| fellow[:id] } })
     @channel.create('gandalf')
@@ -1120,7 +1120,7 @@ describe StreamChat::Client do
       @client = StreamChat::Client.from_env
       @channel_id = SecureRandom.uuid
       @user_id = SecureRandom.uuid
-      
+
       @channel = @client.channel('messaging', channel_id: @channel_id)
       @channel.create(@user_id)
       @channel.update_partial({ config_overrides: { user_message_reminders: true } })

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1119,12 +1119,13 @@ describe StreamChat::Client do
     before do
       @client = StreamChat::Client.from_env
       @channel_id = SecureRandom.uuid
+      @user_id = SecureRandom.uuid
+      
       @channel = @client.channel('messaging', channel_id: @channel_id)
-      @channel.create('john')
+      @channel.create(@user_id)
       @channel.update_partial({ config_overrides: { user_message_reminders: true } })
-      @message = @channel.send_message({ 'text' => 'Hello world' }, 'john')
+      @message = @channel.send_message({ 'text' => 'Hello world' }, @user_id)
       @message_id = @message['message']['id']
-      @user_id = 'john'
     end
 
     describe 'create_reminder' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -26,11 +26,17 @@ describe StreamChat::Client do
     @created_users = []
 
     @fellowship_of_the_ring = [
-      { id: 'frodo-baggins', name: 'Frodo Baggins', race: 'Hobbit', age: 50 },
-      { id: 'sam-gamgee', name: 'Samwise Gamgee', race: 'Hobbit', age: 38 },
-      { id: 'gandalf', name: 'Gandalf the Grey', race: 'Istari' },
-      { id: 'legolas', name: 'Legolas', race: 'Elf', age: 500 }
+      { id: SecureRandom.uuid, name: 'Frodo Baggins', race: 'Hobbit', age: 50 },
+      { id: SecureRandom.uuid, name: 'Samwise Gamgee', race: 'Hobbit', age: 38 },
+      { id: SecureRandom.uuid, name: 'Gandalf the Grey', race: 'Istari' },
+      { id: SecureRandom.uuid, name: 'Legolas', race: 'Elf', age: 500 }
     ]
+
+    @legolas = @fellowship_of_the_ring[3][:id]
+    @gandalf = @fellowship_of_the_ring[2][:id]
+    @frodo = @fellowship_of_the_ring[0][:id]
+    @sam = @fellowship_of_the_ring[1][:id]
+
     @client.upsert_users(@fellowship_of_the_ring)
 
     # Create a new channel for chat max length for channel_id is 64 characters
@@ -38,7 +44,7 @@ describe StreamChat::Client do
 
     @channel = @client.channel('team', channel_id: channel_id,
                                        data: { members: @fellowship_of_the_ring.map { |fellow| fellow[:id] } })
-    @channel.create('gandalf')
+    @channel.create(@gandalf)
   end
 
   before(:each) do
@@ -226,7 +232,7 @@ describe StreamChat::Client do
   end
 
   it 'exports a user' do
-    response = @client.export_user('gandalf')
+    response = @client.export_user(@gandalf)
     expect(response).to include 'user'
     expect(response['user']['name']).to eq('Gandalf the Grey')
   end
@@ -452,7 +458,7 @@ describe StreamChat::Client do
   end
 
   it 'queries channels' do
-    response = @client.query_channels({ 'members' => { '$in' => ['legolas'] } }, sort: { 'id' => 1 })
+    response = @client.query_channels({ 'members' => { '$in' => [@legolas] } }, sort: { 'id' => 1 })
     expect(response['channels'].length).to eq 1
     expect(response['channels'][0]['channel']['id']).to eq @channel.id
     expect(response['channels'][0]['members'].length).to eq 4
@@ -511,41 +517,41 @@ describe StreamChat::Client do
   describe 'search' do
     it 'search for messages' do
       text = SecureRandom.uuid
-      @channel.send_message({ text: text }, 'legolas')
-      resp = @client.search({ members: { '$in' => ['legolas'] } }, text)
+      @channel.send_message({ text: text }, @fellowship_of_the_ring[2][:id])
+      resp = @client.search({ members: { '$in' => [@fellowship_of_the_ring[2][:id]] } }, text)
       p resp
       expect(resp['results'].length).to eq(1)
     end
 
     it 'search for messages with filter conditions' do
       text = SecureRandom.uuid
-      @channel.send_message({ text: text }, 'legolas')
-      resp = @client.search({ members: { '$in' => ['legolas'] } }, { text: { '$q': text } })
+      @channel.send_message({ text: text }, @legolas)
+      resp = @client.search({ members: { '$in' => [@legolas] } }, { text: { '$q': text } })
       expect(resp['results'].length).to eq(1)
     end
 
     it 'offset with sort should fail' do
       expect do
-        @client.search({ members: { '$in' => ['legolas'] } }, SecureRandom.uuid, sort: { created_at: -1 }, offset: 2)
+        @client.search({ members: { '$in' => [@legolas] } }, SecureRandom.uuid, sort: { created_at: -1 }, offset: 2)
       end.to raise_error(/cannot use offset with next or sort parameters/)
     end
 
     it 'offset with next should fail' do
       expect do
-        @client.search({ members: { '$in' => ['legolas'] } }, SecureRandom.uuid, offset: 2, next: SecureRandom.uuid)
+        @client.search({ members: { '$in' => [@legolas] } }, SecureRandom.uuid, offset: 2, next: SecureRandom.uuid)
       end.to raise_error(/cannot use offset with next or sort parameters/)
     end
 
     xit 'search for messages with sorting' do
       text = SecureRandom.uuid
       message_ids = ["0-#{text}", "1-#{text}"]
-      @channel.send_message({ id: message_ids[0], text: text }, 'legolas')
-      @channel.send_message({ id: message_ids[1], text: text }, 'legolas')
-      page1 = @client.search({ members: { '$in' => ['legolas'] } }, text, sort: [{ created_at: -1 }], limit: 1)
+      @channel.send_message({ id: message_ids[0], text: text }, @legolas)
+      @channel.send_message({ id: message_ids[1], text: text }, @legolas)
+      page1 = @client.search({ members: { '$in' => [@legolas] } }, text, sort: [{ created_at: -1 }], limit: 1)
       expect(page1['results'].length).to eq
       expect(page1['results'][0]['message']['id']).to eq(message_ids[1])
       expect(page1['next']).not_to be_empty
-      page2 = @client.search({ members: { '$in' => ['legolas'] } }, text, limit: 1, next: page1['next'])
+      page2 = @client.search({ members: { '$in' => [@legolas] } }, text, limit: 1, next: page1['next'])
       expect(page2['results'].length).to eq(1)
       expect(page2['results'][0]['message']['id']).to eq(message_ids[0])
       expect(page2['previous']).not_to be_empty
@@ -837,7 +843,7 @@ describe StreamChat::Client do
 
   it 'check push notification test are working' do
     message_id = SecureRandom.uuid
-    @channel.send_message({ id: message_id, text: SecureRandom.uuid }, 'legolas')
+    @channel.send_message({ id: message_id, text: SecureRandom.uuid }, @legolas)
     resp = @client.check_push({ message_id: message_id, skip_devices: true, user_id: @random_user[:id] })
     expect(resp['rendered_message']).not_to be_empty
   end
@@ -867,7 +873,7 @@ describe StreamChat::Client do
 
   it 'can translate a message' do
     message_id = SecureRandom.uuid
-    @channel.send_message({ id: message_id, text: SecureRandom.uuid }, 'legolas')
+    @channel.send_message({ id: message_id, text: SecureRandom.uuid }, @legolas)
     response = @client.translate_message(message_id, 'hu')
     expect(response['message']).not_to be_empty
   end
@@ -1127,10 +1133,6 @@ describe StreamChat::Client do
       @user_id = @random_user[:id]
       @message = @channel.send_message({ 'text' => 'Hello world' }, @user_id)
       @message_id = @message['message']['id']
-    end
-
-    after(:all) do
-      @channel.update_partial({ config_overrides: { user_message_reminders: false } })
     end
 
     describe 'create_reminder' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -34,7 +34,7 @@ describe StreamChat::Client do
     @client.upsert_users(@fellowship_of_the_ring)
 
     # Create a new channel for chat max length for channel_id is 64 characters
-    channel_id = 'fellowship-of-the-ring-chat-' + SecureRandom.alphanumeric(20)
+    channel_id = "fellowship-of-the-ring-chat-#{SecureRandom.alphanumeric(20)}"
 
     @channel = @client.channel('team', channel_id: channel_id,
                                        data: { members: @fellowship_of_the_ring.map { |fellow| fellow[:id] } })

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -51,6 +51,8 @@ describe StreamChat::Client do
   end
 
   after(:all) do
+    @channel.delete
+
     @users_to_delete = @created_users.dup + @fellowship_of_the_ring.map { |fellow| fellow[:id] }
     curr_idx = 0
     batch_size = 25
@@ -63,11 +65,6 @@ describe StreamChat::Client do
       curr_idx += batch_size
       slice = @users_to_delete.slice(curr_idx, batch_size)
     end
-
-    @channel.delete
-  rescue StreamChat::StreamAPIException
-    # if the channel is already deleted by the test, we can ignore the error
-    logger.info "Error cleaning up testcase: #{e.message}"
   end
 
   it 'properly sets up a new client' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -453,7 +453,7 @@ describe StreamChat::Client do
 
   it 'queries channels' do
     response = @client.query_channels({ 'members' => { '$in' => ['legolas'] } }, sort: { 'id' => 1 })
-    expect(response['channels'].length).to eq 2
+    expect(response['channels'].length).to eq 1
     expect(response['channels'][0]['channel']['id']).to eq @channel.id
     expect(response['channels'][0]['members'].length).to eq 4
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -32,19 +32,22 @@ describe StreamChat::Client do
       { id: 'legolas', name: 'Legolas', race: 'Elf', age: 500 }
     ]
     @client.upsert_users(@fellowship_of_the_ring)
-    @channel = @client.channel('team', channel_id: 'fellowship-of-the-ring',
+    
+    # Create a new channel for chat max length for channel_id is 64 characters
+    channel_id = 'fellowship-of-the-ring-chat-' + SecureRandom.alphanumeric(20)
+    
+    @channel = @client.channel('team', channel_id: channel_id,
                                        data: { members: @fellowship_of_the_ring.map { |fellow| fellow[:id] } })
     @channel.create('gandalf')
   end
 
   before(:each) do
-    @random_users = [{ id: SecureRandom.uuid }, { id: SecureRandom.uuid }]
-    @random_user = { id: SecureRandom.uuid }
-    users_to_insert = [@random_users[0], @random_users[1], @random_user]
+    @random_users = [{ id: SecureRandom.uuid }, { id: SecureRandom.uuid }, { id: SecureRandom.uuid }]
+    @random_user = @random_users[0]
 
-    @created_users.push(*users_to_insert.map { |u| u[:id] })
+    @created_users.push(*@random_users.map { |u| u[:id] })
 
-    @client.upsert_users(users_to_insert)
+    @client.upsert_users(@random_users)
   end
 
   after(:all) do
@@ -448,7 +451,7 @@ describe StreamChat::Client do
   it 'queries channels' do
     response = @client.query_channels({ 'members' => { '$in' => ['legolas'] } }, sort: { 'id' => 1 })
     expect(response['channels'].length).to eq 1
-    expect(response['channels'][0]['channel']['id']).to eq 'fellowship-of-the-ring'
+    expect(response['channels'][0]['channel']['id']).to eq @channel.id
     expect(response['channels'][0]['members'].length).to eq 4
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -51,19 +51,23 @@ describe StreamChat::Client do
   end
 
   after(:all) do
+    @users_to_delete = @created_users.dup + @fellowship_of_the_ring.map { |fellow| fellow[:id] }
     curr_idx = 0
     batch_size = 25
 
-    slice = @created_users.slice(0, batch_size)
+    slice = @users_to_delete.slice(0, batch_size)
 
     while !slice.nil? && !slice.empty?
       @client.delete_users(slice, user: StreamChat::HARD_DELETE, messages: StreamChat::HARD_DELETE)
 
       curr_idx += batch_size
-      slice = @created_users.slice(curr_idx, batch_size)
+      slice = @users_to_delete.slice(curr_idx, batch_size)
     end
 
     @channel.delete
+  rescue StreamChat::StreamAPIException
+    # if the channel is already deleted by the test, we can ignore the error
+    logger.info "Error cleaning up testcase: #{e.message}"
   end
 
   it 'properly sets up a new client' do

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -34,7 +34,7 @@ describe StreamChat::Moderation do
     @client.upsert_users(@fellowship_of_the_ring)
 
     # Create a new channel for moderation
-    channel_id = 'fellowship-of-the-ring-moderation-' + SecureRandom.alphanumeric(20)
+    channel_id = "fellowship-of-the-ring-moderation-#{SecureRandom.alphanumeric(20)}"
 
     @channel = @client.channel('team', channel_id: channel_id,
                                        data: { members: @fellowship_of_the_ring.map { |fellow| fellow[:id] } })

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -32,7 +32,7 @@ describe StreamChat::Moderation do
       { id: 'legolas', name: 'Legolas', race: 'Elf', age: 500 }
     ]
     @client.upsert_users(@fellowship_of_the_ring)
-    
+
     # Create a new channel for moderation
     channel_id = 'fellowship-of-the-ring-moderation-' + SecureRandom.alphanumeric(20)
 

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -31,6 +31,11 @@ describe StreamChat::Moderation do
       { id: SecureRandom.uuid, name: 'Gandalf the Grey', race: 'Istari' },
       { id: SecureRandom.uuid, name: 'Legolas', race: 'Elf', age: 500 }
     ]
+    @gandalf = @fellowship_of_the_ring[2]
+    @frodo = @fellowship_of_the_ring[0]
+    @sam = @fellowship_of_the_ring[1]
+    @legolas = @fellowship_of_the_ring[3]
+
     @client.upsert_users(@fellowship_of_the_ring)
 
     # Create a new channel for moderation

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -62,6 +62,8 @@ describe StreamChat::Moderation do
       curr_idx += batch_size
       slice = @created_users.slice(curr_idx, batch_size)
     end
+
+    @channel.delete
   end
 
   it 'properly sets up a new client' do

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -32,19 +32,22 @@ describe StreamChat::Moderation do
       { id: 'legolas', name: 'Legolas', race: 'Elf', age: 500 }
     ]
     @client.upsert_users(@fellowship_of_the_ring)
-    @channel = @client.channel('team', channel_id: 'fellowship-of-the-ring',
+    
+    # Create a new channel for moderation
+    channel_id = 'fellowship-of-the-ring-moderation-' + SecureRandom.alphanumeric(20)
+
+    @channel = @client.channel('team', channel_id: channel_id,
                                        data: { members: @fellowship_of_the_ring.map { |fellow| fellow[:id] } })
     @channel.create('gandalf')
   end
 
   before(:each) do
-    @random_users = [{ id: SecureRandom.uuid }, { id: SecureRandom.uuid }]
-    @random_user = { id: SecureRandom.uuid }
-    users_to_insert = [@random_users[0], @random_users[1], @random_user]
+    @random_users = [{ id: SecureRandom.uuid }, { id: SecureRandom.uuid }, { id: SecureRandom.uuid }]
+    @random_user = @random_users[0]
 
-    @created_users.push(*users_to_insert.map { |u| u[:id] })
+    @created_users.push(*@random_users.map { |u| u[:id] })
 
-    @client.upsert_users(users_to_insert)
+    @client.upsert_users(@random_users)
   end
 
   after(:all) do

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -54,13 +54,15 @@ describe StreamChat::Moderation do
     curr_idx = 0
     batch_size = 25
 
-    slice = @created_users.slice(0, batch_size)
+    @users_to_delete = @created_users.dup + @fellowship_of_the_ring.map { |fellow| fellow[:id] }
+
+    slice = @users_to_delete.slice(0, batch_size)
 
     while !slice.nil? && !slice.empty?
       @client.delete_users(slice, user: StreamChat::HARD_DELETE, messages: StreamChat::HARD_DELETE)
 
       curr_idx += batch_size
-      slice = @created_users.slice(curr_idx, batch_size)
+      slice = @users_to_delete.slice(curr_idx, batch_size)
     end
 
     @channel.delete

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -52,7 +52,7 @@ describe StreamChat::Moderation do
 
   after(:all) do
     @channel.delete
-    
+
     curr_idx = 0
     batch_size = 25
 
@@ -66,7 +66,6 @@ describe StreamChat::Moderation do
       curr_idx += batch_size
       slice = @users_to_delete.slice(curr_idx, batch_size)
     end
-
   end
 
   it 'properly sets up a new client' do

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -26,10 +26,10 @@ describe StreamChat::Moderation do
     @created_users = []
 
     @fellowship_of_the_ring = [
-      { id: 'frodo-baggins', name: 'Frodo Baggins', race: 'Hobbit', age: 50 },
-      { id: 'sam-gamgee', name: 'Samwise Gamgee', race: 'Hobbit', age: 38 },
-      { id: 'gandalf', name: 'Gandalf the Grey', race: 'Istari' },
-      { id: 'legolas', name: 'Legolas', race: 'Elf', age: 500 }
+      { id: SecureRandom.uuid, name: 'Frodo Baggins', race: 'Hobbit', age: 50 },
+      { id: SecureRandom.uuid, name: 'Samwise Gamgee', race: 'Hobbit', age: 38 },
+      { id: SecureRandom.uuid, name: 'Gandalf the Grey', race: 'Istari' },
+      { id: SecureRandom.uuid, name: 'Legolas', race: 'Elf', age: 500 }
     ]
     @client.upsert_users(@fellowship_of_the_ring)
 
@@ -38,7 +38,7 @@ describe StreamChat::Moderation do
 
     @channel = @client.channel('team', channel_id: channel_id,
                                        data: { members: @fellowship_of_the_ring.map { |fellow| fellow[:id] } })
-    @channel.create('gandalf')
+    @channel.create(@fellowship_of_the_ring[2][:id])
   end
 
   before(:each) do

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -51,6 +51,8 @@ describe StreamChat::Moderation do
   end
 
   after(:all) do
+    @channel.delete
+    
     curr_idx = 0
     batch_size = 25
 
@@ -65,7 +67,6 @@ describe StreamChat::Moderation do
       slice = @users_to_delete.slice(curr_idx, batch_size)
     end
 
-    @channel.delete
   end
 
   it 'properly sets up a new client' do


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
The test suite was experiencing flakiness due to hardcoded user IDs and channel IDs that could cause conflicts between test runs, especially when running tests in parallel or consecutively without proper cleanup.

### Changes Made

#### 🔧 Dynamic User ID Generation
- **Before**: Used hardcoded user IDs like `'frodo-baggins'`, `'sam-gamgee'`, `'gandalf'`, `'legolas'`
- **After**: Generate unique user IDs using `SecureRandom.uuid` for each test run
- **Impact**: Eliminates user ID conflicts between test runs

#### 🏗️ Dynamic Channel ID Generation  
- **Before**: Used hardcoded channel ID `'fellowship-of-the-ring'`
- **After**: Generate unique channel IDs using `"fellowship-of-the-ring-chat-#{SecureRandom.alphanumeric(20)}"` pattern
- **Impact**: Prevents channel conflicts and ensures proper test isolation

#### 🧹 Improved Test Cleanup
- Added proper channel cleanup in `after(:all)` hook with `@channel.delete`
- Enhanced user deletion to include both random users and fellowship users
- Updated user deletion logic to handle all created users consistently
- **Impact**: Ensures no leftover data affects subsequent test runs

#### 📝 Consistent Reference Management
- Updated all hardcoded string references to use dynamically generated IDs stored in instance variables
- Fixed user creation logic to be more consistent and trackable
- Updated search and query tests to use dynamic user references
- **Impact**: Ensures all test operations use the correct dynamic identifiers

#### 🎯 Specific Test Improvements
- **Reminders tests**: Improved setup to use existing test infrastructure instead of creating separate client/channel
- **Export user test**: Updated to use dynamic `@gandalf` variable instead of hardcoded `'gandalf'`
- **Search tests**: Updated to use dynamic user references for better isolation

### Files Modified
- `spec/client_spec.rb` - Main client test suite with comprehensive flakiness fixes
- `spec/moderation_spec.rb` - Moderation test suite with similar isolation improvements