### PR TITLE
[MOD2-818] Add delete_reactions support for ban user

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -265,6 +265,10 @@ describe StreamChat::Client do
     @client.ban_user(@random_user[:id], user_id: @random_users[0][:id])
   end
 
+  it 'bans a user with delete_reactions' do
+    @client.ban_user(@random_user[:id], user_id: @random_users[0][:id], delete_reactions: true)
+  end
+
   it 'unbans a user' do
     @client.ban_user(@random_user[:id], user_id: @random_users[0][:id])
     @client.unban_user(@random_user[:id], user_id: @random_users[0][:id])


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/MOD2-818

## Summary
Adds support for the new `delete_reactions` boolean parameter in the ban API that removes reactions by the banned user on other users' messages when pruning messages.

The Ruby SDK uses the `**options` kwargs pattern, so the `delete_reactions` parameter flows through automatically. This PR adds a test to verify the parameter is accepted by the API.

## Related
- Backend PR: https://github.com/GetStream/chat/pull/12495

## Checklist
- [x] The changed code has been covered with unit tests
- [ ] API endpoints are covered with client tests
- [ ] The internal documentation (`./docs`) has been updated