### PR TITLE
chore: relax jwt dependency to allow v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,18 @@ jobs:
             lint: true
           - ruby: "3.4"
             lint: true
-    name: 💎 Ruby ${{ matrix.ruby }}
+          # Exercise jwt v3 alongside the default v2 resolution.
+          - ruby: "4.0"
+            jwt: "~> 3.0"
+    name: 💎 Ruby ${{ matrix.ruby }}${{ matrix.jwt && format(' (jwt {0})', matrix.jwt) || '' }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # gives the commit linter access to previous commits
+
+      - name: Pin jwt to ${{ matrix.jwt }}
+        if: matrix.jwt
+        run: echo "gem 'jwt', '${{ matrix.jwt }}'" >> Gemfile
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/docs/best_practices/moderation.md
+++ b/docs/best_practices/moderation.md
@@ -99,7 +99,7 @@ client.update_channel_type(
 
 ### Blocklist
 
-A Blocklist is a list of words that you can use to moderate chat messages. Stream Chat comes with a built-in Blocklist called `profanity_en_2020_v1` which contains over a thousand of the most common profane words.
+A Blocklist is a list of words that you can use to moderate chat messages. Stream Chat comes with a built-in Blocklist called `profanity` which contains over a thousand of the most common profane words.
 
 You can manage your own blocklists via the Stream dashboard or APIs to a manage blocklists and configure your channel types to use them. Channel types can be configured to block or flag messages from your users based on your blocklists. To do this you need to configure your channel type(s) with these two configurations: `blocklist` and `blocklist_behavior` . The first one refers to the name of the blocklist and the second must be set as `block` or `flag` .
 
@@ -145,7 +145,7 @@ client.update_channel_type("messaging", blocklist: "no-cakes", blocklist_behavio
 
 #### List available blocklists
 
-All applications have the `profanity_en_2020_v1` blocklist available. This endpoint returns all blocklists available for this application.
+All applications have the `profanity` blocklist available. This endpoint returns all blocklists available for this application.
 
 ```ruby
 client.list_blocklists()

--- a/docs/webhooks/webhook_events.md
+++ b/docs/webhooks/webhook_events.md
@@ -574,7 +574,7 @@ When applicable, the following attributes are included to the event user and to 
       "blocklist_behavior": "flag",
       "blocklists": [
         {
-          "blocklist": "profanity_en_2020_v1",
+          "blocklist": "profanity",
           "behavior": "block"
         }
       ],
@@ -877,7 +877,7 @@ When applicable, the following attributes are included to the event user and to 
         "max_message_length": 5000,
         "automod": "disabled",
         "automod_behavior": "flag",
-        "blocklist": "profanity_en_2020_v1",
+        "blocklist": "profanity",
         "blocklist_behavior": "block",
         "automod_thresholds": {},
         "commands": [

--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -20,7 +20,7 @@ require 'stream-chat/moderation'
 require 'stream-chat/channel_batch_updater'
 
 module StreamChat
-  DEFAULT_BLOCKLIST = 'profanity_en_2020_v1'
+  DEFAULT_BLOCKLIST = 'profanity'
   SOFT_DELETE = 'soft'
   HARD_DELETE = 'hard'
 
@@ -739,7 +739,7 @@ module StreamChat
     # Returns all blocklists.
     #
     # A Block List is a list of words that you can use to moderate chat messages. Stream Chat
-    # comes with a built-in Block List called profanity_en_2020_v1 which contains over a thousand
+    # comes with a built-in Block List called profanity which contains over a thousand
     # of the most common profane words.
     # You can manage your own block lists via the Stream dashboard or APIs to a manage
     # blocklists and configure your channel types to use them.
@@ -751,7 +751,7 @@ module StreamChat
     # Returns a blocklist.
     #
     # A Block List is a list of words that you can use to moderate chat messages. Stream Chat
-    # comes with a built-in Block List called profanity_en_2020_v1 which contains over a thousand
+    # comes with a built-in Block List called profanity which contains over a thousand
     # of the most common profane words.
     # You can manage your own block lists via the Stream dashboard or APIs to a manage
     # blocklists and configure your channel types to use them.
@@ -763,7 +763,7 @@ module StreamChat
     # Creates a blocklist.
     #
     # A Block List is a list of words that you can use to moderate chat messages. Stream Chat
-    # comes with a built-in Block List called profanity_en_2020_v1 which contains over a thousand
+    # comes with a built-in Block List called profanity which contains over a thousand
     # of the most common profane words.
     # You can manage your own block lists via the Stream dashboard or APIs to a manage
     # blocklists and configure your channel types to use them.
@@ -775,7 +775,7 @@ module StreamChat
     # Updates a blocklist.
     #
     # A Block List is a list of words that you can use to moderate chat messages. Stream Chat
-    # comes with a built-in Block List called profanity_en_2020_v1 which contains over a thousand
+    # comes with a built-in Block List called profanity which contains over a thousand
     # of the most common profane words.
     # You can manage your own block lists via the Stream dashboard or APIs to a manage
     # blocklists and configure your channel types to use them.
@@ -787,7 +787,7 @@ module StreamChat
     # Deletes a blocklist.
     #
     # A Block List is a list of words that you can use to moderate chat messages. Stream Chat
-    # comes with a built-in Block List called profanity_en_2020_v1 which contains over a thousand
+    # comes with a built-in Block List called profanity which contains over a thousand
     # of the most common profane words.
     # You can manage your own block lists via the Stream dashboard or APIs to a manage
     # blocklists and configure your channel types to use them.

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -8698,8 +8698,6 @@ end
 
 class StringScanner
   def bol?(); end
-
-  def initialize(*arg); end
   Id = ::T.let(nil, ::T.untyped)
   Version = ::T.let(nil, ::T.untyped)
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -118,7 +118,7 @@ describe StreamChat::Client do
 
   it 'creates a user token' do
     token = @client.create_token('tommaso')
-    payload = JWT.decode(token, @client.api_secret)
+    payload = JWT.decode(token, @client.api_secret, true, { algorithm: 'HS256' })
     expect(payload[0].fetch('user_id')).to eq 'tommaso'
   end
 

--- a/spec/moderation_spec.rb
+++ b/spec/moderation_spec.rb
@@ -197,7 +197,7 @@ describe StreamChat::Moderation do
           enabled: true,
           rules: [
             {
-              name: 'profanity_en_2020_v1',
+              name: StreamChat::DEFAULT_BLOCKLIST,
               action: 'flag'
             }
           ]

--- a/stream-chat.gemspec
+++ b/stream-chat.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 2.12'
   gem.add_dependency 'faraday-multipart', '~> 1.1'
   gem.add_dependency 'faraday-net_http_persistent', '~> 2.3'
-  gem.add_dependency 'jwt', '~> 2.10'
+  gem.add_dependency 'jwt', '>= 2.10', '< 4'
   gem.add_dependency 'net-http-persistent', '~> 4.0'
   gem.add_dependency 'sorbet-runtime', '>= 0.5.11820', '< 1'
 end


### PR DESCRIPTION
## Summary
- Relax `jwt` constraint in the gemspec to `>= 2.10, < 4` so apps can resolve to ruby-jwt v3 (originally proposed in #207 by @sergiopatricio, fixes #204).
- Add a CI matrix entry pinning `jwt ~> 3.0` so v3 compatibility is verified by tests, not just by inspection.
- Tighten `spec/client_spec.rb` to pass an explicit `HS256` algorithm to `JWT.decode` — header-inferred algorithms have shifted across jwt major versions and are brittle.
- Rename `profanity_en_2020_v1` blocklist name to `profanity`.

## Test plan
- [ ] Default matrix (jwt 2.x) still passes on Ruby 3.0 / 3.1 / 3.4 / 4.0
- [ ] New `Ruby 4.0 (jwt ~> 3.0)` matrix entry passes
- [ ] Lint (rubocop + srb tc) still green on Ruby 3.4 / 4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)