### PR TITLE
feat(webhooks): verify_and_parse_* API for compressed payloads (CHA-3071)

### DIFF
--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -110,7 +110,7 @@ Before enabling compression, make sure that:
 
 ### Decoding a compressed webhook in Ruby (Rails)
 
-The Ruby SDK exposes three composite helpers on `StreamChat::Client`, one per transport, so you do not have to wire `Zlib`, `Base64`, and `OpenSSL::HMAC` together yourself. Each method decodes the body, verifies the `X-Signature` HMAC against the **uncompressed** JSON, parses the JSON, and returns the event as a `Hash`. Any failure (bad signature, malformed gzip, malformed base64) raises `StreamChat::WebhookSignatureError`.
+The Ruby SDK exposes three composite helpers on `StreamChat::Client`, one per transport, so you do not have to wire `Zlib`, `Base64`, and `OpenSSL::HMAC` together yourself. Each method decodes the body, verifies the `X-Signature` HMAC against the **uncompressed** JSON, parses the JSON, and returns the event as a `Hash`. Any failure (bad signature, malformed gzip, malformed base64) raises `StreamChat::InvalidWebhookError`.
 
 * `verify_and_parse_webhook(body, x_signature)` — HTTP webhooks.
 * `verify_and_parse_sqs(message_body, x_signature)` — SQS firehose messages (base64 + optional gzip).
@@ -136,7 +136,7 @@ class WebhooksController < ApplicationController
 
     Rails.logger.info("Stream webhook: #{event['type']}")
     head :ok
-  rescue StreamChat::WebhookSignatureError => e
+  rescue StreamChat::InvalidWebhookError => e
     Rails.logger.warn("Rejected Stream webhook: #{e.message}")
     head :unauthorized
   end
@@ -165,7 +165,7 @@ resp.messages.each do |msg|
   # ...handle event...
 
   sqs.delete_message(queue_url: ENV.fetch('STREAM_SQS_URL'), receipt_handle: msg.receipt_handle)
-rescue StreamChat::WebhookSignatureError => e
+rescue StreamChat::InvalidWebhookError => e
   # do NOT delete the message - leave it for the DLQ / retry policy
   Rails.logger.warn("Rejected Stream SQS message: #{e.message}")
 end

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -96,6 +96,95 @@ All webhook requests contain these headers:
 | X-Api-Key         | Your application’s API key. Should be used to validate request signature                                             | a1b23cdefgh4                                                     |
 | X-Signature       | HMAC signature of the request body. See Signature section                                                            | ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb |
 
+## Compressed webhook bodies
+
+GZIP compression can be enabled for hooks payloads from the Dashboard. Enabling compression reduces the payload size significantly (often 70–90% smaller) reducing your bandwidth usage on Stream. The computation overhead introduced by the decompression step is usually negligible and offset by the much smaller payload.
+
+When payload compression is enabled, webhook HTTP requests will include the `Content-Encoding: gzip` header and the request body will be compressed with GZIP. Some HTTP servers and middleware (Rails, Django, Laravel, Spring Boot, ASP.NET) handle this transparently and strip the header before your handler runs — in that case the body you see is already raw JSON.
+
+Before enabling compression, make sure that:
+
+* Your backend integration is using a recent version of our official SDKs with compression support
+* If you don't use an official SDK, make sure that your code supports receiving compressed payloads
+* The payload signature check is done on the **uncompressed** payload
+
+### Decoding a compressed webhook in Ruby (Rails)
+
+The Ruby SDK exposes two helpers on `StreamChat::Client` so you do not have to wire `Zlib` and `OpenSSL::HMAC` together yourself:
+
+* `decompress_webhook_body(body, content_encoding = nil, payload_encoding = nil)` — primitive that just decodes the body. No signature check.
+* `verify_and_decode_webhook(body, x_signature, content_encoding = nil, payload_encoding = nil)` — decodes **and** verifies the `X-Signature` HMAC against the uncompressed JSON. Raises `StreamChat::WebhookSignatureError` if anything is wrong.
+
+Both methods return the raw JSON bytes as a binary `String`; you can `.force_encoding('UTF-8')` it or pass it straight to `JSON.parse`. Passing `nil` (or an empty string) for either encoding is a no-op, so the same handler works whether or not compression is enabled.
+
+```ruby
+require 'stream-chat'
+require 'json'
+
+STREAM_CLIENT = StreamChat::Client.new('STREAM_KEY', 'STREAM_SECRET')
+
+class WebhooksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def stream
+    body = request.raw_post # binary safe; do NOT use params
+
+    json_bytes = STREAM_CLIENT.verify_and_decode_webhook(
+      body,
+      request.headers['X-Signature'],
+      request.headers['Content-Encoding'] # 'gzip' when compressed, nil otherwise
+    )
+
+    event = JSON.parse(json_bytes)
+    Rails.logger.info("Stream webhook: #{event['type']}")
+
+    head :ok
+  rescue StreamChat::WebhookSignatureError => e
+    Rails.logger.warn("Rejected Stream webhook: #{e.message}")
+    head :unauthorized
+  end
+end
+```
+
+> [!NOTE]
+> If you sit behind middleware that already inflates `Content-Encoding: gzip` requests for you, pass `nil` for `content_encoding` (or just don't forward the header) — `request.raw_post` will already be raw JSON.
+
+### Decoding a compressed SQS / SNS firehose message
+
+SQS and SNS message bodies must be valid UTF-8, so when GZIP compression is enabled the gzipped bytes are additionally **base64-wrapped** before being placed on the queue. Pass `payload_encoding: 'base64'` so the SDK unwraps the queue envelope before decompressing:
+
+```ruby
+require 'aws-sdk-sqs'
+require 'json'
+require 'stream-chat'
+
+client = StreamChat::Client.new('STREAM_KEY', 'STREAM_SECRET')
+sqs = Aws::SQS::Client.new
+
+resp = sqs.receive_message(queue_url: ENV.fetch('STREAM_SQS_URL'), max_number_of_messages: 10)
+
+resp.messages.each do |msg|
+  attrs = msg.message_attributes || {}
+  signature        = attrs.dig('X-Signature',     :string_value)
+  content_encoding = attrs.dig('Content-Encoding', :string_value) # 'gzip' when compressed
+  payload_encoding = attrs.dig('Payload-Encoding', :string_value) || 'base64'
+
+  json_bytes = client.verify_and_decode_webhook(
+    msg.body,
+    signature,
+    content_encoding,
+    payload_encoding
+  )
+
+  event = JSON.parse(json_bytes)
+  # ...handle the event...
+
+  sqs.delete_message(queue_url: ENV.fetch('STREAM_SQS_URL'), receipt_handle: msg.receipt_handle)
+end
+```
+
+The exact attribute names that carry the signature and encoding metadata may vary — refer to the SQS / SNS pages in this section for the up-to-date list. The decoding rules themselves do not change: signature is always computed over the **uncompressed** JSON.
+
 ## Webhook types
 
 In addition to the above there are 3 special webhooks.

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -112,9 +112,20 @@ Before enabling compression, make sure that:
 
 The Ruby SDK exposes three composite helpers on `StreamChat::Client`, one per transport, so you do not have to wire `Zlib`, `Base64`, and `OpenSSL::HMAC` together yourself. Each method decodes the body, verifies the `X-Signature` HMAC against the **uncompressed** JSON, parses the JSON, and returns the event as a `Hash`. Any failure (bad signature, malformed gzip, malformed base64) raises `StreamChat::InvalidWebhookError`.
 
-* `verify_and_parse_webhook(body, x_signature)` — HTTP webhooks.
-* `verify_and_parse_sqs(message_body, x_signature)` — SQS firehose messages (base64 + optional gzip).
-* `verify_and_parse_sns(message, x_signature)` — SNS notification messages (base64 + optional gzip).
+* `verify_and_parse_webhook(body, x_signature)` — HTTP webhooks. Signature required.
+* `verify_and_parse_sqs(message_body)` — SQS firehose messages (base64 + optional gzip). Signature is optional; see note below.
+* `verify_and_parse_sns(notification_body)` — SNS notification messages (envelope JSON or pre-extracted `Message`, base64 + optional gzip). Signature is optional; see note below.
+
+> [!NOTE]
+> Stream does **not** ship an `X-Signature` for SQS or SNS deliveries.
+> Those transports ride AWS-internal infrastructure
+> (IAM-authenticated queues, AWS-signed SNS notifications), so an
+> additional HMAC on top is redundant. `verify_and_parse_sqs` and
+> `verify_and_parse_sns` therefore accept the signature as an optional
+> second argument: omit it to decode + parse, or pass it (together with
+> the client's API secret, which the instance helpers wire up for you)
+> to opt into the legacy verification path. Passing exactly one of
+> (signature, secret) raises `InvalidWebhookError`.
 
 GZIP is detected from the body bytes (the `1f 8b` magic prefix), not from the `Content-Encoding` header, so the same handler works whether or not your HTTP server transparently decompresses the request body before it reaches you.
 
@@ -147,7 +158,7 @@ If you also want to support the legacy "I just want to check the signature mysel
 
 ### Decoding a compressed SQS / SNS firehose message
 
-SQS and SNS message bodies must be valid UTF-8, so when GZIP compression is enabled the gzipped bytes are additionally **base64-wrapped** before being placed on the queue. `verify_and_parse_sqs` (and its SNS twin) unwrap the queue envelope before verifying the signature, so the same call works whether or not compression is enabled:
+SQS and SNS message bodies must be valid UTF-8, so when GZIP compression is enabled the gzipped bytes are additionally **base64-wrapped** before being placed on the queue. `verify_and_parse_sqs` (and its SNS twin) unwrap the queue envelope (base64, then gzip-if-magic) before returning the parsed event, so the same call works whether or not compression is enabled:
 
 ```ruby
 require 'aws-sdk-sqs'
@@ -159,9 +170,7 @@ sqs = Aws::SQS::Client.new
 resp = sqs.receive_message(queue_url: ENV.fetch('STREAM_SQS_URL'), max_number_of_messages: 10)
 
 resp.messages.each do |msg|
-  signature = msg.message_attributes&.dig('X-Signature', :string_value)
-
-  event = client.verify_and_parse_sqs(msg.body, signature)
+  event = client.verify_and_parse_sqs(msg.body)
   # ...handle event...
 
   sqs.delete_message(queue_url: ENV.fetch('STREAM_SQS_URL'), receipt_handle: msg.receipt_handle)
@@ -171,7 +180,27 @@ rescue StreamChat::InvalidWebhookError => e
 end
 ```
 
-The exact attribute name that carries the signature may vary — refer to the SQS / SNS pages in this section for the up-to-date list. The decoding rules themselves do not change: the signature is always computed over the **uncompressed** JSON.
+For SNS HTTP notifications the call is symmetrical — pass the full
+notification body (the JSON envelope) straight in and the SDK unwraps
+the `Message` field for you:
+
+```ruby
+require 'stream-chat'
+
+client = StreamChat::Client.new('STREAM_KEY', 'STREAM_SECRET')
+
+post '/webhooks/stream/sns' do
+  envelope_body = request.body.read
+  event = client.verify_and_parse_sns(envelope_body)
+  # ...handle event...
+  status 200
+rescue StreamChat::InvalidWebhookError => e
+  Rails.logger.warn("Rejected Stream SNS notification: #{e.message}")
+  status 400
+end
+```
+
+If your integration was previously passing an `X-Signature` to `verify_and_parse_sqs` / `verify_and_parse_sns`, you can keep doing so — pass the signature as the second argument and the instance method will reuse the client's API secret to verify it.
 
 If you need to build a custom pipeline, the module-level primitives are also exposed: `StreamChat::Webhook.gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload`, `verify_signature`, and `parse_event`. The composite `verify_and_parse_*` methods are thin wrappers on top of these.
 

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -173,7 +173,7 @@ end
 
 The exact attribute name that carries the signature may vary — refer to the SQS / SNS pages in this section for the up-to-date list. The decoding rules themselves do not change: the signature is always computed over the **uncompressed** JSON.
 
-If you need to build a custom pipeline, the module-level primitives are also exposed: `StreamChat::Webhook.ungzip_payload`, `decode_sqs_payload`, `decode_sns_payload`, `verify_signature`, and `parse_event`. The composite `verify_and_parse_*` methods are thin wrappers on top of these.
+If you need to build a custom pipeline, the module-level primitives are also exposed: `StreamChat::Webhook.gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload`, `verify_signature`, and `parse_event`. The composite `verify_and_parse_*` methods are thin wrappers on top of these.
 
 ## Webhook types
 

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -110,16 +110,16 @@ Before enabling compression, make sure that:
 
 ### Decoding a compressed webhook in Ruby (Rails)
 
-The Ruby SDK exposes two helpers on `StreamChat::Client` so you do not have to wire `Zlib` and `OpenSSL::HMAC` together yourself:
+The Ruby SDK exposes three composite helpers on `StreamChat::Client`, one per transport, so you do not have to wire `Zlib`, `Base64`, and `OpenSSL::HMAC` together yourself. Each method decodes the body, verifies the `X-Signature` HMAC against the **uncompressed** JSON, parses the JSON, and returns the event as a `Hash`. Any failure (bad signature, malformed gzip, malformed base64) raises `StreamChat::WebhookSignatureError`.
 
-* `decompress_webhook_body(body, content_encoding = nil, payload_encoding = nil)` — primitive that just decodes the body. No signature check.
-* `verify_and_decode_webhook(body, x_signature, content_encoding = nil, payload_encoding = nil)` — decodes **and** verifies the `X-Signature` HMAC against the uncompressed JSON. Raises `StreamChat::WebhookSignatureError` if anything is wrong.
+* `verify_and_parse_webhook(body, x_signature)` — HTTP webhooks.
+* `verify_and_parse_sqs(message_body, x_signature)` — SQS firehose messages (base64 + optional gzip).
+* `verify_and_parse_sns(message, x_signature)` — SNS notification messages (base64 + optional gzip).
 
-Both methods return the raw JSON bytes as a binary `String`; you can `.force_encoding('UTF-8')` it or pass it straight to `JSON.parse`. Passing `nil` (or an empty string) for either encoding is a no-op, so the same handler works whether or not compression is enabled.
+GZIP is detected from the body bytes (the `1f 8b` magic prefix), not from the `Content-Encoding` header, so the same handler works whether or not your HTTP server transparently decompresses the request body before it reaches you.
 
 ```ruby
 require 'stream-chat'
-require 'json'
 
 STREAM_CLIENT = StreamChat::Client.new('STREAM_KEY', 'STREAM_SECRET')
 
@@ -129,15 +129,12 @@ class WebhooksController < ApplicationController
   def stream
     body = request.raw_post # binary safe; do NOT use params
 
-    json_bytes = STREAM_CLIENT.verify_and_decode_webhook(
+    event = STREAM_CLIENT.verify_and_parse_webhook(
       body,
-      request.headers['X-Signature'],
-      request.headers['Content-Encoding'] # 'gzip' when compressed, nil otherwise
+      request.headers['X-Signature']
     )
 
-    event = JSON.parse(json_bytes)
     Rails.logger.info("Stream webhook: #{event['type']}")
-
     head :ok
   rescue StreamChat::WebhookSignatureError => e
     Rails.logger.warn("Rejected Stream webhook: #{e.message}")
@@ -146,16 +143,14 @@ class WebhooksController < ApplicationController
 end
 ```
 
-> [!NOTE]
-> If you sit behind middleware that already inflates `Content-Encoding: gzip` requests for you, pass `nil` for `content_encoding` (or just don't forward the header) — `request.raw_post` will already be raw JSON.
+If you also want to support the legacy "I just want to check the signature myself" flow, `client.verify_webhook(body, x_signature)` is still available and returns a boolean. It does **not** handle compression — use `verify_and_parse_webhook` for new integrations.
 
 ### Decoding a compressed SQS / SNS firehose message
 
-SQS and SNS message bodies must be valid UTF-8, so when GZIP compression is enabled the gzipped bytes are additionally **base64-wrapped** before being placed on the queue. Pass `payload_encoding: 'base64'` so the SDK unwraps the queue envelope before decompressing:
+SQS and SNS message bodies must be valid UTF-8, so when GZIP compression is enabled the gzipped bytes are additionally **base64-wrapped** before being placed on the queue. `verify_and_parse_sqs` (and its SNS twin) unwrap the queue envelope before verifying the signature, so the same call works whether or not compression is enabled:
 
 ```ruby
 require 'aws-sdk-sqs'
-require 'json'
 require 'stream-chat'
 
 client = StreamChat::Client.new('STREAM_KEY', 'STREAM_SECRET')
@@ -164,26 +159,21 @@ sqs = Aws::SQS::Client.new
 resp = sqs.receive_message(queue_url: ENV.fetch('STREAM_SQS_URL'), max_number_of_messages: 10)
 
 resp.messages.each do |msg|
-  attrs = msg.message_attributes || {}
-  signature        = attrs.dig('X-Signature',     :string_value)
-  content_encoding = attrs.dig('Content-Encoding', :string_value) # 'gzip' when compressed
-  payload_encoding = attrs.dig('Payload-Encoding', :string_value) || 'base64'
+  signature = msg.message_attributes&.dig('X-Signature', :string_value)
 
-  json_bytes = client.verify_and_decode_webhook(
-    msg.body,
-    signature,
-    content_encoding,
-    payload_encoding
-  )
-
-  event = JSON.parse(json_bytes)
-  # ...handle the event...
+  event = client.verify_and_parse_sqs(msg.body, signature)
+  # ...handle event...
 
   sqs.delete_message(queue_url: ENV.fetch('STREAM_SQS_URL'), receipt_handle: msg.receipt_handle)
+rescue StreamChat::WebhookSignatureError => e
+  # do NOT delete the message - leave it for the DLQ / retry policy
+  Rails.logger.warn("Rejected Stream SQS message: #{e.message}")
 end
 ```
 
-The exact attribute names that carry the signature and encoding metadata may vary — refer to the SQS / SNS pages in this section for the up-to-date list. The decoding rules themselves do not change: signature is always computed over the **uncompressed** JSON.
+The exact attribute name that carries the signature may vary — refer to the SQS / SNS pages in this section for the up-to-date list. The decoding rules themselves do not change: the signature is always computed over the **uncompressed** JSON.
+
+If you need to build a custom pipeline, the module-level primitives are also exposed: `StreamChat::Webhook.ungzip_payload`, `decode_sqs_payload`, `decode_sns_payload`, `verify_signature`, and `parse_event`. The composite `verify_and_parse_*` methods are thin wrappers on top of these.
 
 ## Webhook types
 

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -110,22 +110,16 @@ Before enabling compression, make sure that:
 
 ### Decoding a compressed webhook in Ruby (Rails)
 
-The Ruby SDK exposes three composite helpers on `StreamChat::Client`, one per transport, so you do not have to wire `Zlib`, `Base64`, and `OpenSSL::HMAC` together yourself. Each method decodes the body, verifies the `X-Signature` HMAC against the **uncompressed** JSON, parses the JSON, and returns the event as a `Hash`. Any failure (bad signature, malformed gzip, malformed base64) raises `StreamChat::InvalidWebhookError`.
+The Ruby SDK exposes three composite helpers on `StreamChat::Client`, one per transport, so you do not have to wire `Zlib`, `Base64`, and `OpenSSL::HMAC` together yourself:
 
-* `verify_and_parse_webhook(body, x_signature)` — HTTP webhooks. Signature required.
-* `verify_and_parse_sqs(message_body)` — SQS firehose messages (base64 + optional gzip). Signature is optional; see note below.
-* `verify_and_parse_sns(notification_body)` — SNS notification messages (envelope JSON or pre-extracted `Message`, base64 + optional gzip). Signature is optional; see note below.
+* `verify_and_parse_webhook(body, x_signature)` — HTTP webhooks: gunzip when needed, **verify** `X-Signature` against the **uncompressed** JSON (using the client's API secret), then parse.
+* `parse_sqs(message_body)` — SQS `Body`: base64-decode + optional gzip, then parse. **No** application-level signature.
+* `parse_sns(notification_body)` — SNS: unwrap the JSON envelope when needed, same inner decode path as SQS. **No** application-level signature.
 
 > [!NOTE]
-> Stream does **not** ship an `X-Signature` for SQS or SNS deliveries.
-> Those transports ride AWS-internal infrastructure
-> (IAM-authenticated queues, AWS-signed SNS notifications), so an
-> additional HMAC on top is redundant. `verify_and_parse_sqs` and
-> `verify_and_parse_sns` therefore accept the signature as an optional
-> second argument: omit it to decode + parse, or pass it (together with
-> the client's API secret, which the instance helpers wire up for you)
-> to opt into the legacy verification path. Passing exactly one of
-> (signature, secret) raises `InvalidWebhookError`.
+> Stream does **not** ship an `X-Signature` for SQS or SNS hook payloads — those transports are authenticated by AWS (IAM for SQS, SNS signing for HTTPS). Call `parse_sqs` / `parse_sns` with the message body only.
+
+All three raise `StreamChat::InvalidWebhookError` on malformed gzip, base64, or JSON. Only `verify_and_parse_webhook` raises on HMAC mismatch.
 
 GZIP is detected from the body bytes (the `1f 8b` magic prefix), not from the `Content-Encoding` header, so the same handler works whether or not your HTTP server transparently decompresses the request body before it reaches you.
 
@@ -158,7 +152,7 @@ If you also want to support the legacy "I just want to check the signature mysel
 
 ### Decoding a compressed SQS / SNS firehose message
 
-SQS and SNS message bodies must be valid UTF-8, so when GZIP compression is enabled the gzipped bytes are additionally **base64-wrapped** before being placed on the queue. `verify_and_parse_sqs` (and its SNS twin) unwrap the queue envelope (base64, then gzip-if-magic) before returning the parsed event, so the same call works whether or not compression is enabled:
+SQS and SNS message bodies must be valid UTF-8, so when GZIP compression is enabled the gzipped bytes are additionally **base64-wrapped** before being placed on the queue. `parse_sqs` (and `parse_sns`) unwrap the queue envelope (base64, then gzip-if-magic) before returning the parsed event, so the same call works whether or not compression is enabled:
 
 ```ruby
 require 'aws-sdk-sqs'
@@ -170,7 +164,7 @@ sqs = Aws::SQS::Client.new
 resp = sqs.receive_message(queue_url: ENV.fetch('STREAM_SQS_URL'), max_number_of_messages: 10)
 
 resp.messages.each do |msg|
-  event = client.verify_and_parse_sqs(msg.body)
+  event = client.parse_sqs(msg.body)
   # ...handle event...
 
   sqs.delete_message(queue_url: ENV.fetch('STREAM_SQS_URL'), receipt_handle: msg.receipt_handle)
@@ -191,7 +185,7 @@ client = StreamChat::Client.new('STREAM_KEY', 'STREAM_SECRET')
 
 post '/webhooks/stream/sns' do
   envelope_body = request.body.read
-  event = client.verify_and_parse_sns(envelope_body)
+  event = client.parse_sns(envelope_body)
   # ...handle event...
   status 200
 rescue StreamChat::InvalidWebhookError => e
@@ -200,9 +194,7 @@ rescue StreamChat::InvalidWebhookError => e
 end
 ```
 
-If your integration was previously passing an `X-Signature` to `verify_and_parse_sqs` / `verify_and_parse_sns`, you can keep doing so — pass the signature as the second argument and the instance method will reuse the client's API secret to verify it.
-
-If you need to build a custom pipeline, the module-level primitives are also exposed: `StreamChat::Webhook.gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload`, `verify_signature`, and `parse_event`. The composite `verify_and_parse_*` methods are thin wrappers on top of these.
+If you need to build a custom pipeline, the module-level primitives are also exposed: `StreamChat::Webhook.gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload`, `verify_signature`, and `parse_event`. The composites `verify_and_parse_webhook`, `parse_sqs`, and `parse_sns` are thin wrappers on top of these.
 
 ## Webhook types
 

--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -711,6 +711,9 @@ module StreamChat
     sig { params(request_body: String, x_signature: String).returns(T::Boolean) }
     def verify_webhook(request_body, x_signature)
       StreamChat::Webhook.verify_signature(request_body, x_signature, @api_secret)
+      true
+    rescue StreamChat::InvalidWebhookError
+      false
     end
 
     # Verify and parse an HTTP webhook event.
@@ -724,7 +727,7 @@ module StreamChat
     #   signed.
     # @param signature [String] Value of the `X-Signature` header.
     # @return [Hash] The parsed event.
-    # @raise [WebhookSignatureError] When the signature does not match or the
+    # @raise [InvalidWebhookError] When the signature does not match or the
     #   gzip envelope is malformed.
     sig do
       params(
@@ -745,7 +748,7 @@ module StreamChat
     # @param message_body [String] SQS message `Body` string.
     # @param signature [String] Value of the `X-Signature` message attribute.
     # @return [Hash] The parsed event.
-    # @raise [WebhookSignatureError]
+    # @raise [InvalidWebhookError]
     sig { params(message_body: String, signature: String).returns(T::Hash[String, T.untyped]) }
     def verify_and_parse_sqs(message_body, signature)
       StreamChat::Webhook.verify_and_parse_sqs(message_body, signature, @api_secret)
@@ -760,7 +763,7 @@ module StreamChat
     # @param message [String] SNS notification `Message` field.
     # @param signature [String] Value of the `X-Signature` message attribute.
     # @return [Hash] The parsed event.
-    # @raise [WebhookSignatureError]
+    # @raise [InvalidWebhookError]
     sig { params(message: String, signature: String).returns(T::Hash[String, T.untyped]) }
     def verify_and_parse_sns(message, signature)
       StreamChat::Webhook.verify_and_parse_sns(message, signature, @api_secret)

--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -703,69 +703,67 @@ module StreamChat
       get('rate_limits', params: params)
     end
 
-    # Verify the signature added to a webhook event.
+    # Verify the signature on a webhook event using the client's API secret.
+    #
+    # Backward-compatible boolean helper. New integrations should call
+    # {#verify_and_parse_webhook} (or the SQS / SNS variants), which also handle
+    # gzip payload compression and return the parsed event.
     sig { params(request_body: String, x_signature: String).returns(T::Boolean) }
     def verify_webhook(request_body, x_signature)
-      signature = OpenSSL::HMAC.hexdigest('SHA256', @api_secret, request_body)
-      signature == x_signature
+      StreamChat::Webhook.verify_signature(request_body, x_signature, @api_secret)
     end
 
-    # Decodes a webhook body that may have been base64-wrapped (SQS / SNS) and
-    # / or gzip-compressed (Content-Encoding: gzip), without verifying the
-    # signature. Returns the raw JSON bytes as a binary `String`; callers can
-    # `.force_encoding('UTF-8')` or pass the result to `JSON.parse` directly.
+    # Verify and parse an HTTP webhook event.
     #
-    # @param body [String, Array<Integer>] The raw webhook payload.
-    # @param content_encoding [String, nil] Value of the `Content-Encoding`
-    #   HTTP header (or the corresponding SQS / SNS message attribute). Pass
-    #   `nil` or an empty string to skip decompression.
-    # @param payload_encoding [String, nil] How the queue wrapped the bytes,
-    #   typically `"base64"` for SQS / SNS firehoses. Pass `nil` for plain
-    #   HTTP webhooks.
-    # @return [String] Uncompressed JSON bytes (binary encoded).
+    # Decompresses `body` when gzipped (detected from the body bytes), verifies
+    # the `X-Signature` header against the client's API secret, and returns the
+    # parsed event as a `Hash`. Typed event classes are planned for a future
+    # release.
+    #
+    # @param body [String, Array<Integer>] Raw HTTP request body bytes Stream
+    #   signed.
+    # @param signature [String] Value of the `X-Signature` header.
+    # @return [Hash] The parsed event.
+    # @raise [WebhookSignatureError] When the signature does not match or the
+    #   gzip envelope is malformed.
     sig do
       params(
         body: T.any(String, T::Array[Integer]),
-        content_encoding: T.nilable(String),
-        payload_encoding: T.nilable(String)
-      ).returns(String)
+        signature: String
+      ).returns(T::Hash[String, T.untyped])
     end
-    def decompress_webhook_body(body, content_encoding = nil, payload_encoding = nil)
-      raw = StreamChat::Webhook.normalize_body(body)
-      raw = StreamChat::Webhook.apply_payload_encoding(raw, payload_encoding)
-      StreamChat::Webhook.apply_content_encoding(raw, content_encoding)
+    def verify_and_parse_webhook(body, signature)
+      StreamChat::Webhook.verify_and_parse_webhook(body, signature, @api_secret)
     end
 
-    # Decodes a (possibly base64-wrapped, possibly gzip-compressed) webhook
-    # body and verifies its `X-Signature` HMAC against `@api_secret`. The
-    # signature is always computed over the *uncompressed* JSON bytes — both
-    # for plain HTTP webhooks and for SQS / SNS messages — matching what the
-    # Stream backend signs.
+    # Verify and parse an SQS firehose webhook event.
     #
-    # @param body [String, Array<Integer>] The raw webhook payload.
-    # @param x_signature [String] Value of the `X-Signature` header (or the
-    #   corresponding SQS / SNS message attribute).
-    # @param content_encoding [String, nil] Value of the `Content-Encoding`
-    #   HTTP header. `nil` or empty means the body is already raw JSON.
-    # @param payload_encoding [String, nil] Set to `"base64"` for SQS / SNS
-    #   firehose envelopes; `nil` for plain HTTP.
-    # @return [String] Uncompressed JSON bytes (binary encoded).
-    # @raise [WebhookSignatureError] if decoding fails or the signature does
-    #   not match.
-    sig do
-      params(
-        body: T.any(String, T::Array[Integer]),
-        x_signature: String,
-        content_encoding: T.nilable(String),
-        payload_encoding: T.nilable(String)
-      ).returns(String)
+    # Reverses the base64 (+ optional gzip) wrapping on the SQS `Body`,
+    # verifies the `X-Signature` message attribute against the client's API
+    # secret, and returns the parsed event.
+    #
+    # @param message_body [String] SQS message `Body` string.
+    # @param signature [String] Value of the `X-Signature` message attribute.
+    # @return [Hash] The parsed event.
+    # @raise [WebhookSignatureError]
+    sig { params(message_body: String, signature: String).returns(T::Hash[String, T.untyped]) }
+    def verify_and_parse_sqs(message_body, signature)
+      StreamChat::Webhook.verify_and_parse_sqs(message_body, signature, @api_secret)
     end
-    def verify_and_decode_webhook(body, x_signature, content_encoding = nil, payload_encoding = nil)
-      decoded = decompress_webhook_body(body, content_encoding, payload_encoding)
-      expected = OpenSSL::HMAC.hexdigest('SHA256', @api_secret, decoded)
-      raise WebhookSignatureError, 'invalid webhook signature' unless StreamChat::Webhook.constant_time_equal?(expected, x_signature)
 
-      decoded
+    # Verify and parse an SNS firehose webhook event.
+    #
+    # Reverses the base64 (+ optional gzip) wrapping on the SNS notification
+    # `Message`, verifies the `X-Signature` message attribute against the
+    # client's API secret, and returns the parsed event.
+    #
+    # @param message [String] SNS notification `Message` field.
+    # @param signature [String] Value of the `X-Signature` message attribute.
+    # @return [Hash] The parsed event.
+    # @raise [WebhookSignatureError]
+    sig { params(message: String, signature: String).returns(T::Hash[String, T.untyped]) }
+    def verify_and_parse_sns(message, signature)
+      StreamChat::Webhook.verify_and_parse_sns(message, signature, @api_secret)
     end
 
     # Allows you to send custom events to a connected user.

--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -1,7 +1,11 @@
 # typed: strict
 # frozen_string_literal: true
 
+require 'base64'
 require 'open-uri'
+require 'openssl'
+require 'stringio'
+require 'zlib'
 require 'faraday'
 require 'faraday/multipart'
 require 'faraday/net_http_persistent'
@@ -18,6 +22,7 @@ require 'stream-chat/util'
 require 'stream-chat/types'
 require 'stream-chat/moderation'
 require 'stream-chat/channel_batch_updater'
+require 'stream-chat/webhook'
 
 module StreamChat
   DEFAULT_BLOCKLIST = 'profanity'
@@ -703,6 +708,64 @@ module StreamChat
     def verify_webhook(request_body, x_signature)
       signature = OpenSSL::HMAC.hexdigest('SHA256', @api_secret, request_body)
       signature == x_signature
+    end
+
+    # Decodes a webhook body that may have been base64-wrapped (SQS / SNS) and
+    # / or gzip-compressed (Content-Encoding: gzip), without verifying the
+    # signature. Returns the raw JSON bytes as a binary `String`; callers can
+    # `.force_encoding('UTF-8')` or pass the result to `JSON.parse` directly.
+    #
+    # @param body [String, Array<Integer>] The raw webhook payload.
+    # @param content_encoding [String, nil] Value of the `Content-Encoding`
+    #   HTTP header (or the corresponding SQS / SNS message attribute). Pass
+    #   `nil` or an empty string to skip decompression.
+    # @param payload_encoding [String, nil] How the queue wrapped the bytes,
+    #   typically `"base64"` for SQS / SNS firehoses. Pass `nil` for plain
+    #   HTTP webhooks.
+    # @return [String] Uncompressed JSON bytes (binary encoded).
+    sig do
+      params(
+        body: T.any(String, T::Array[Integer]),
+        content_encoding: T.nilable(String),
+        payload_encoding: T.nilable(String)
+      ).returns(String)
+    end
+    def decompress_webhook_body(body, content_encoding = nil, payload_encoding = nil)
+      raw = StreamChat::Webhook.normalize_body(body)
+      raw = StreamChat::Webhook.apply_payload_encoding(raw, payload_encoding)
+      StreamChat::Webhook.apply_content_encoding(raw, content_encoding)
+    end
+
+    # Decodes a (possibly base64-wrapped, possibly gzip-compressed) webhook
+    # body and verifies its `X-Signature` HMAC against `@api_secret`. The
+    # signature is always computed over the *uncompressed* JSON bytes — both
+    # for plain HTTP webhooks and for SQS / SNS messages — matching what the
+    # Stream backend signs.
+    #
+    # @param body [String, Array<Integer>] The raw webhook payload.
+    # @param x_signature [String] Value of the `X-Signature` header (or the
+    #   corresponding SQS / SNS message attribute).
+    # @param content_encoding [String, nil] Value of the `Content-Encoding`
+    #   HTTP header. `nil` or empty means the body is already raw JSON.
+    # @param payload_encoding [String, nil] Set to `"base64"` for SQS / SNS
+    #   firehose envelopes; `nil` for plain HTTP.
+    # @return [String] Uncompressed JSON bytes (binary encoded).
+    # @raise [WebhookSignatureError] if decoding fails or the signature does
+    #   not match.
+    sig do
+      params(
+        body: T.any(String, T::Array[Integer]),
+        x_signature: String,
+        content_encoding: T.nilable(String),
+        payload_encoding: T.nilable(String)
+      ).returns(String)
+    end
+    def verify_and_decode_webhook(body, x_signature, content_encoding = nil, payload_encoding = nil)
+      decoded = decompress_webhook_body(body, content_encoding, payload_encoding)
+      expected = OpenSSL::HMAC.hexdigest('SHA256', @api_secret, decoded)
+      raise WebhookSignatureError, 'invalid webhook signature' unless StreamChat::Webhook.constant_time_equal?(expected, x_signature)
+
+      decoded
     end
 
     # Allows you to send custom events to a connected user.

--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -724,7 +724,7 @@ module StreamChat
     #   signed.
     # @param signature [String] Value of the `X-Signature` header.
     # @return [Hash] The parsed event.
-    # @raise [WebhookSignatureError] When the signature does not match or the
+    # @raise [InvalidWebhookError] When the signature does not match or the
     #   gzip envelope is malformed.
     sig do
       params(
@@ -740,7 +740,7 @@ module StreamChat
     #
     # @param message_body [String] SQS message `Body` string.
     # @return [Hash] The parsed event.
-    # @raise [WebhookSignatureError] on malformed base64 or gzip envelope
+    # @raise [InvalidWebhookError] on malformed base64 or gzip envelope
     sig { params(message_body: String).returns(T::Hash[String, T.untyped]) }
     def parse_sqs(message_body)
       StreamChat::Webhook.parse_sqs(message_body)
@@ -750,7 +750,7 @@ module StreamChat
     #
     # @param message [String] Raw SNS POST body or pre-extracted Message string.
     # @return [Hash] The parsed event.
-    # @raise [WebhookSignatureError] on decode failures
+    # @raise [InvalidWebhookError] on decode failures
     sig { params(message: String).returns(T::Hash[String, T.untyped]) }
     def parse_sns(message)
       StreamChat::Webhook.parse_sns(message)

--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -711,9 +711,6 @@ module StreamChat
     sig { params(request_body: String, x_signature: String).returns(T::Boolean) }
     def verify_webhook(request_body, x_signature)
       StreamChat::Webhook.verify_signature(request_body, x_signature, @api_secret)
-      true
-    rescue StreamChat::InvalidWebhookError
-      false
     end
 
     # Verify and parse an HTTP webhook event.
@@ -727,7 +724,7 @@ module StreamChat
     #   signed.
     # @param signature [String] Value of the `X-Signature` header.
     # @return [Hash] The parsed event.
-    # @raise [InvalidWebhookError] When the signature does not match or the
+    # @raise [WebhookSignatureError] When the signature does not match or the
     #   gzip envelope is malformed.
     sig do
       params(
@@ -739,48 +736,24 @@ module StreamChat
       StreamChat::Webhook.verify_and_parse_webhook(body, signature, @api_secret)
     end
 
-    # Verify and parse an SQS firehose webhook event.
-    #
-    # Reverses the base64 (+ optional gzip) wrapping on the SQS `Body` and
-    # returns the parsed event. When `signature` is provided, the HMAC is
-    # verified against the client's API secret; when omitted, signature
-    # verification is skipped (Stream's SQS deliveries are not signed).
+    # Parse an SQS-delivered webhook event (decode only; Stream does not HMAC-sign SQS bodies).
     #
     # @param message_body [String] SQS message `Body` string.
-    # @param signature [String, nil] Value of the `X-Signature` message
-    #   attribute, or `nil` to skip verification.
     # @return [Hash] The parsed event.
-    # @raise [InvalidWebhookError]
-    sig { params(message_body: String, signature: T.nilable(String)).returns(T::Hash[String, T.untyped]) }
-    def verify_and_parse_sqs(message_body, signature = nil)
-      if signature.nil?
-        StreamChat::Webhook.verify_and_parse_sqs(message_body)
-      else
-        StreamChat::Webhook.verify_and_parse_sqs(message_body, signature, @api_secret)
-      end
+    # @raise [WebhookSignatureError] on malformed base64 or gzip envelope
+    sig { params(message_body: String).returns(T::Hash[String, T.untyped]) }
+    def parse_sqs(message_body)
+      StreamChat::Webhook.parse_sqs(message_body)
     end
 
-    # Verify and parse an SNS firehose webhook event.
+    # Parse an SNS-delivered webhook event (unwraps envelope JSON when needed).
     #
-    # Reverses the base64 (+ optional gzip) wrapping on the SNS notification
-    # `Message` and returns the parsed event. When `signature` is provided,
-    # the HMAC is verified against the client's API secret; when omitted,
-    # signature verification is skipped (Stream's SNS deliveries are not
-    # signed by Stream — they carry AWS's own SNS signature).
-    #
-    # @param notification_body [String] SNS notification body (envelope JSON
-    #   or pre-extracted `Message` field).
-    # @param signature [String, nil] Value of the `X-Signature` message
-    #   attribute, or `nil` to skip verification.
+    # @param message [String] Raw SNS POST body or pre-extracted Message string.
     # @return [Hash] The parsed event.
-    # @raise [InvalidWebhookError]
-    sig { params(notification_body: String, signature: T.nilable(String)).returns(T::Hash[String, T.untyped]) }
-    def verify_and_parse_sns(notification_body, signature = nil)
-      if signature.nil?
-        StreamChat::Webhook.verify_and_parse_sns(notification_body)
-      else
-        StreamChat::Webhook.verify_and_parse_sns(notification_body, signature, @api_secret)
-      end
+    # @raise [WebhookSignatureError] on decode failures
+    sig { params(message: String).returns(T::Hash[String, T.untyped]) }
+    def parse_sns(message)
+      StreamChat::Webhook.parse_sns(message)
     end
 
     # Allows you to send custom events to a connected user.

--- a/lib/stream-chat/client.rb
+++ b/lib/stream-chat/client.rb
@@ -741,32 +741,46 @@ module StreamChat
 
     # Verify and parse an SQS firehose webhook event.
     #
-    # Reverses the base64 (+ optional gzip) wrapping on the SQS `Body`,
-    # verifies the `X-Signature` message attribute against the client's API
-    # secret, and returns the parsed event.
+    # Reverses the base64 (+ optional gzip) wrapping on the SQS `Body` and
+    # returns the parsed event. When `signature` is provided, the HMAC is
+    # verified against the client's API secret; when omitted, signature
+    # verification is skipped (Stream's SQS deliveries are not signed).
     #
     # @param message_body [String] SQS message `Body` string.
-    # @param signature [String] Value of the `X-Signature` message attribute.
+    # @param signature [String, nil] Value of the `X-Signature` message
+    #   attribute, or `nil` to skip verification.
     # @return [Hash] The parsed event.
     # @raise [InvalidWebhookError]
-    sig { params(message_body: String, signature: String).returns(T::Hash[String, T.untyped]) }
-    def verify_and_parse_sqs(message_body, signature)
-      StreamChat::Webhook.verify_and_parse_sqs(message_body, signature, @api_secret)
+    sig { params(message_body: String, signature: T.nilable(String)).returns(T::Hash[String, T.untyped]) }
+    def verify_and_parse_sqs(message_body, signature = nil)
+      if signature.nil?
+        StreamChat::Webhook.verify_and_parse_sqs(message_body)
+      else
+        StreamChat::Webhook.verify_and_parse_sqs(message_body, signature, @api_secret)
+      end
     end
 
     # Verify and parse an SNS firehose webhook event.
     #
     # Reverses the base64 (+ optional gzip) wrapping on the SNS notification
-    # `Message`, verifies the `X-Signature` message attribute against the
-    # client's API secret, and returns the parsed event.
+    # `Message` and returns the parsed event. When `signature` is provided,
+    # the HMAC is verified against the client's API secret; when omitted,
+    # signature verification is skipped (Stream's SNS deliveries are not
+    # signed by Stream — they carry AWS's own SNS signature).
     #
-    # @param message [String] SNS notification `Message` field.
-    # @param signature [String] Value of the `X-Signature` message attribute.
+    # @param notification_body [String] SNS notification body (envelope JSON
+    #   or pre-extracted `Message` field).
+    # @param signature [String, nil] Value of the `X-Signature` message
+    #   attribute, or `nil` to skip verification.
     # @return [Hash] The parsed event.
     # @raise [InvalidWebhookError]
-    sig { params(message: String, signature: String).returns(T::Hash[String, T.untyped]) }
-    def verify_and_parse_sns(message, signature)
-      StreamChat::Webhook.verify_and_parse_sns(message, signature, @api_secret)
+    sig { params(notification_body: String, signature: T.nilable(String)).returns(T::Hash[String, T.untyped]) }
+    def verify_and_parse_sns(notification_body, signature = nil)
+      if signature.nil?
+        StreamChat::Webhook.verify_and_parse_sns(notification_body)
+      else
+        StreamChat::Webhook.verify_and_parse_sns(notification_body, signature, @api_secret)
+      end
     end
 
     # Allows you to send custom events to a connected user.

--- a/lib/stream-chat/errors.rb
+++ b/lib/stream-chat/errors.rb
@@ -47,4 +47,8 @@ module StreamChat
   end
 
   class StreamChannelException < StandardError; end
+
+  # Raised by webhook verify/parse helpers when the HMAC does not match or a
+  # gzip/base64 envelope cannot be decoded.
+  class WebhookSignatureError < StandardError; end
 end

--- a/lib/stream-chat/errors.rb
+++ b/lib/stream-chat/errors.rb
@@ -47,4 +47,34 @@ module StreamChat
   end
 
   class StreamChannelException < StandardError; end
+
+  # Raised when a webhook payload cannot be decoded, decompressed, or its
+  # signature does not match the expected HMAC. Carries a human readable
+  # reason instead of an HTTP response so it can be raised from the local
+  # webhook helpers (decompress / verify) without involving Faraday.
+  class WebhookSignatureError < StreamAPIException
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :reason
+
+    sig { params(reason: String).void }
+    def initialize(reason) # rubocop:disable Lint/MissingSuper
+      @reason = T.let(reason, String)
+      @json_response = T.let(false, T::Boolean)
+      @error_code = T.let(0, Integer)
+      @error_message = T.let(reason, String)
+      StandardError.instance_method(:initialize).bind_call(self, reason)
+    end
+
+    sig { returns(String) }
+    def message
+      @reason
+    end
+
+    sig { returns(String) }
+    def to_s
+      @reason
+    end
+  end
 end

--- a/lib/stream-chat/errors.rb
+++ b/lib/stream-chat/errors.rb
@@ -49,6 +49,13 @@ module StreamChat
   class StreamChannelException < StandardError; end
 
   # Raised by webhook verify/parse helpers when the HMAC does not match or a
-  # gzip/base64 envelope cannot be decoded.
-  class WebhookSignatureError < StandardError; end
+  # gzip/base64/JSON envelope cannot be decoded. The message identifies which
+  # failure mode fired; the class-level constants below are the canonical
+  # strings for callers that prefer exact-match filtering over substring.
+  class InvalidWebhookError < StandardError
+    SIGNATURE_MISMATCH = 'signature mismatch'
+    INVALID_BASE64 = 'invalid base64 encoding'
+    GZIP_FAILED = 'gzip decompression failed'
+    INVALID_JSON = 'invalid JSON payload'
+  end
 end

--- a/lib/stream-chat/errors.rb
+++ b/lib/stream-chat/errors.rb
@@ -49,32 +49,19 @@ module StreamChat
   class StreamChannelException < StandardError; end
 
   # Raised when a webhook payload cannot be decoded, decompressed, or its
-  # signature does not match the expected HMAC. Carries a human readable
-  # reason instead of an HTTP response so it can be raised from the local
-  # webhook helpers (decompress / verify) without involving Faraday.
-  class WebhookSignatureError < StreamAPIException
+  # signature does not match the expected HMAC. This is a local verification
+  # failure with no HTTP response attached, so it inherits directly from
+  # `StandardError` rather than `StreamAPIException`.
+  class WebhookSignatureError < StandardError
     extend T::Sig
 
     sig { returns(String) }
     attr_reader :reason
 
     sig { params(reason: String).void }
-    def initialize(reason) # rubocop:disable Lint/MissingSuper
+    def initialize(reason)
       @reason = T.let(reason, String)
-      @json_response = T.let(false, T::Boolean)
-      @error_code = T.let(0, Integer)
-      @error_message = T.let(reason, String)
-      StandardError.instance_method(:initialize).bind_call(self, reason)
-    end
-
-    sig { returns(String) }
-    def message
-      @reason
-    end
-
-    sig { returns(String) }
-    def to_s
-      @reason
+      super
     end
   end
 end

--- a/lib/stream-chat/errors.rb
+++ b/lib/stream-chat/errors.rb
@@ -47,21 +47,4 @@ module StreamChat
   end
 
   class StreamChannelException < StandardError; end
-
-  # Raised when a webhook payload cannot be decoded, decompressed, or its
-  # signature does not match the expected HMAC. This is a local verification
-  # failure with no HTTP response attached, so it inherits directly from
-  # `StandardError` rather than `StreamAPIException`.
-  class WebhookSignatureError < StandardError
-    extend T::Sig
-
-    sig { returns(String) }
-    attr_reader :reason
-
-    sig { params(reason: String).void }
-    def initialize(reason)
-      @reason = T.let(reason, String)
-      super
-    end
-  end
 end

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'base64'
+require 'json'
 require 'openssl'
 require 'sorbet-runtime'
 require 'stringio'
@@ -10,15 +11,21 @@ require 'zlib'
 require 'stream-chat/errors'
 
 module StreamChat
-  # Stateless helpers used by the webhook decoding and verification methods on
-  # `StreamChat::Client`. Kept in a module so the decode/verify primitives can
-  # be exercised in isolation, and so `Client#verify_webhook` (the legacy
-  # boolean-returning helper) stays untouched for backward compatibility.
-  module Webhook
+  # Stateless helpers implementing the cross-SDK webhook contract documented at
+  # https://getstream.io/chat/docs/node/webhooks_overview/.
+  #
+  # The composite functions (`verify_and_parse_webhook`, `verify_and_parse_sqs`,
+  # `verify_and_parse_sns`) are the recommended entry points. The primitives
+  # they compose (`ungzip_payload`, `decode_sqs_payload`, `decode_sns_payload`,
+  # `verify_signature`, `parse_event`) are exposed so callers can build custom
+  # flows or run individual steps in isolation.
+  #
+  # The Ruby SDK currently returns the parsed JSON as a `Hash`; typed event
+  # classes will land in a future release.
+  module Webhook # rubocop:disable Metrics/ModuleLength
     extend T::Sig
 
-    SUPPORTED_CONTENT_ENCODINGS = T.let(%w[gzip].freeze, T::Array[String])
-    SUPPORTED_PAYLOAD_ENCODINGS = T.let(%w[base64 b64].freeze, T::Array[String])
+    GZIP_MAGIC = T.let("\x1f\x8b\x08".b.freeze, String)
 
     # Coerces the webhook body into a binary `String` regardless of whether
     # the caller hands us a `String` (HTTP `request.raw_post`) or an array of
@@ -35,47 +42,132 @@ module StreamChat
       raw.force_encoding(Encoding::ASCII_8BIT)
     end
 
-    # Decodes the outer `payload_encoding` wrapper if present. SQS / SNS
-    # base64-wrap the gzipped bytes so they remain valid UTF-8 over the queue;
-    # plain HTTP webhooks pass `nil` here and this is a no-op.
-    sig { params(body: String, payload_encoding: T.nilable(String)).returns(String) }
-    def self.apply_payload_encoding(body, payload_encoding)
-      normalized = payload_encoding.to_s.strip.downcase
-      return body if normalized.empty?
+    # Returns `body` unchanged unless it starts with the gzip magic
+    # (`1f 8b 08`), in which case the gzip stream is inflated and the
+    # decompressed bytes are returned.
+    #
+    # Magic-byte detection (rather than relying on a header) keeps the same
+    # handler correct when middleware - Rack, Rails - auto-decompresses the
+    # request before your code sees it.
+    sig { params(body: T.any(String, T::Array[Integer])).returns(String) }
+    def self.ungzip_payload(body)
+      raw = normalize_body(body)
+      return raw unless raw.start_with?(GZIP_MAGIC)
 
-      case normalized
-      when 'base64', 'b64'
-        decoded =
-          begin
-            Base64.strict_decode64(body)
-          rescue ArgumentError => e
-            raise WebhookSignatureError, "failed to decode webhook body using payload_encoding=#{normalized}: #{e.message}"
-          end
-        String.new(decoded).force_encoding(Encoding::ASCII_8BIT)
-      else
-        raise WebhookSignatureError, "unsupported webhook payload_encoding: #{normalized}. This SDK only supports base64."
+      begin
+        Zlib::GzipReader.new(StringIO.new(raw)).read.force_encoding(Encoding::ASCII_8BIT)
+      rescue Zlib::Error => e
+        raise WebhookSignatureError, "failed to decompress gzip payload: #{e.message}"
       end
     end
 
-    # Decompresses the payload according to the HTTP `Content-Encoding`
-    # header reported by the dashboard / SQS message attribute. `nil` /
-    # empty means the body is already the raw JSON document.
-    sig { params(body: String, content_encoding: T.nilable(String)).returns(String) }
-    def self.apply_content_encoding(body, content_encoding)
-      normalized = content_encoding.to_s.strip.downcase
-      return body if normalized.empty?
-
-      case normalized
-      when 'gzip'
+    # Reverses the SQS firehose envelope: the message `Body` is base64-decoded
+    # and, when the result begins with the gzip magic, gzip-decompressed. The
+    # same call works whether or not Stream is currently compressing payloads.
+    sig { params(body: String).returns(String) }
+    def self.decode_sqs_payload(body)
+      decoded =
         begin
-          inflated = Zlib::GzipReader.new(StringIO.new(body)).read
-        rescue Zlib::Error => e
-          raise WebhookSignatureError, "failed to decompress webhook body: #{e.message}"
+          Base64.strict_decode64(body)
+        rescue ArgumentError => e
+          raise WebhookSignatureError, "failed to base64-decode payload: #{e.message}"
         end
-        String.new(inflated).force_encoding(Encoding::ASCII_8BIT)
-      else
-        raise WebhookSignatureError, %(unsupported webhook Content-Encoding: #{normalized}. This SDK only supports gzip; set webhook_compression_algorithm to "gzip" on the app config.)
-      end
+      ungzip_payload(decoded)
+    end
+
+    # Identical to `decode_sqs_payload`; exposed under both names so call sites
+    # read intent.
+    sig { params(message: String).returns(String) }
+    def self.decode_sns_payload(message)
+      decode_sqs_payload(message)
+    end
+
+    # Constant-time HMAC-SHA256 verification of `signature` against the digest
+    # of `body` keyed by `secret`.
+    #
+    # The signature is always computed over the **uncompressed** JSON bytes,
+    # so callers that decoded a gzipped or base64-wrapped payload must pass
+    # the inflated bytes here.
+    sig do
+      params(
+        body: T.any(String, T::Array[Integer]),
+        signature: String,
+        secret: String
+      ).returns(T::Boolean)
+    end
+    def self.verify_signature(body, signature, secret)
+      raw = normalize_body(body)
+      expected = OpenSSL::HMAC.hexdigest('SHA256', secret, raw)
+      constant_time_equal?(expected, signature)
+    end
+
+    # Parse a JSON-encoded webhook event into a `Hash`.
+    #
+    # The Ruby SDK currently returns the parsed JSON as a `Hash`; typed event
+    # classes will land in a future release. The function name matches the
+    # documented primitive so callers can swap in a typed parser later without
+    # changing call sites.
+    sig { params(payload: String).returns(T::Hash[String, T.untyped]) }
+    def self.parse_event(payload)
+      result = JSON.parse(payload)
+      raise WebhookSignatureError, 'failed to parse webhook event: top-level value is not an object' unless result.is_a?(Hash)
+
+      result
+    end
+
+    sig do
+      params(
+        payload: String,
+        signature: String,
+        secret: String
+      ).returns(T::Hash[String, T.untyped])
+    end
+    def self.verify_and_parse_internal(payload, signature, secret)
+      raise WebhookSignatureError, 'invalid webhook signature' unless verify_signature(payload, signature, secret)
+
+      parse_event(payload)
+    end
+    private_class_method :verify_and_parse_internal
+
+    # Decompress `body` when gzipped, verify the HMAC `signature`, and return
+    # the parsed event.
+    sig do
+      params(
+        body: T.any(String, T::Array[Integer]),
+        signature: String,
+        secret: String
+      ).returns(T::Hash[String, T.untyped])
+    end
+    def self.verify_and_parse_webhook(body, signature, secret)
+      verify_and_parse_internal(ungzip_payload(body), signature, secret)
+    end
+
+    # Decode the SQS `Body` (base64, then gzip-if-magic), verify the HMAC
+    # `signature` from the `X-Signature` message attribute, and return the
+    # parsed event.
+    sig do
+      params(
+        message_body: String,
+        signature: String,
+        secret: String
+      ).returns(T::Hash[String, T.untyped])
+    end
+    def self.verify_and_parse_sqs(message_body, signature, secret)
+      verify_and_parse_internal(decode_sqs_payload(message_body), signature, secret)
+    end
+
+    # Decode the SNS notification `Message` (identical to SQS handling), verify
+    # the HMAC `signature` from the `X-Signature` message attribute, and return
+    # the parsed event.
+    sig do
+      params(
+        message: String,
+        signature: String,
+        secret: String
+      ).returns(T::Hash[String, T.untyped])
+    end
+    def self.verify_and_parse_sns(message, signature, secret)
+      verify_and_parse_internal(decode_sns_payload(message), signature, secret)
     end
 
     # Timing-safe equality check used to compare the locally computed HMAC

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -1,0 +1,102 @@
+# typed: strict
+# frozen_string_literal: true
+
+require 'base64'
+require 'openssl'
+require 'sorbet-runtime'
+require 'stringio'
+require 'zlib'
+
+require 'stream-chat/errors'
+
+module StreamChat
+  # Stateless helpers used by the webhook decoding and verification methods on
+  # `StreamChat::Client`. Kept in a module so the decode/verify primitives can
+  # be exercised in isolation, and so `Client#verify_webhook` (the legacy
+  # boolean-returning helper) stays untouched for backward compatibility.
+  module Webhook
+    extend T::Sig
+
+    SUPPORTED_CONTENT_ENCODINGS = T.let(%w[gzip].freeze, T::Array[String])
+    SUPPORTED_PAYLOAD_ENCODINGS = T.let(%w[base64 b64].freeze, T::Array[String])
+
+    # Coerces the webhook body into a binary `String` regardless of whether
+    # the caller hands us a `String` (HTTP `request.raw_post`) or an array of
+    # bytes (which is what some Ruby SQS clients yield when the message body
+    # is binary safe).
+    sig { params(body: T.any(String, T::Array[Integer])).returns(String) }
+    def self.normalize_body(body)
+      raw =
+        if body.is_a?(Array)
+          body.pack('C*')
+        else
+          String.new(body)
+        end
+      raw.force_encoding(Encoding::ASCII_8BIT)
+    end
+
+    # Decodes the outer `payload_encoding` wrapper if present. SQS / SNS
+    # base64-wrap the gzipped bytes so they remain valid UTF-8 over the queue;
+    # plain HTTP webhooks pass `nil` here and this is a no-op.
+    sig { params(body: String, payload_encoding: T.nilable(String)).returns(String) }
+    def self.apply_payload_encoding(body, payload_encoding)
+      normalized = payload_encoding.to_s.strip.downcase
+      return body if normalized.empty?
+
+      case normalized
+      when 'base64', 'b64'
+        decoded =
+          begin
+            Base64.strict_decode64(body)
+          rescue ArgumentError => e
+            raise WebhookSignatureError, "failed to decode webhook body using payload_encoding=#{normalized}: #{e.message}"
+          end
+        String.new(decoded).force_encoding(Encoding::ASCII_8BIT)
+      else
+        raise WebhookSignatureError, "unsupported webhook payload_encoding: #{normalized}. This SDK only supports base64."
+      end
+    end
+
+    # Decompresses the payload according to the HTTP `Content-Encoding`
+    # header reported by the dashboard / SQS message attribute. `nil` /
+    # empty means the body is already the raw JSON document.
+    sig { params(body: String, content_encoding: T.nilable(String)).returns(String) }
+    def self.apply_content_encoding(body, content_encoding)
+      normalized = content_encoding.to_s.strip.downcase
+      return body if normalized.empty?
+
+      case normalized
+      when 'gzip'
+        begin
+          inflated = Zlib::GzipReader.new(StringIO.new(body)).read
+        rescue Zlib::Error => e
+          raise WebhookSignatureError, "failed to decompress webhook body: #{e.message}"
+        end
+        String.new(inflated).force_encoding(Encoding::ASCII_8BIT)
+      else
+        raise WebhookSignatureError, %(unsupported webhook Content-Encoding: #{normalized}. This SDK only supports gzip; set webhook_compression_algorithm to "gzip" on the app config.)
+      end
+    end
+
+    # Timing-safe equality check used to compare the locally computed HMAC
+    # with the `X-Signature` header. Prefers the OpenSSL primitive when the
+    # Ruby build exposes it, otherwise falls back to a manual byte XOR loop
+    # that does not short-circuit on the first mismatch.
+    sig { params(left: String, right: String).returns(T::Boolean) }
+    def self.constant_time_equal?(left, right)
+      a = left.b
+      b = right.b
+      return false unless a.bytesize == b.bytesize
+
+      if OpenSSL.respond_to?(:fixed_length_secure_compare)
+        OpenSSL.fixed_length_secure_compare(a, b)
+      else
+        a_bytes = a.bytes
+        b_bytes = b.bytes
+        diff = 0
+        a_bytes.each_with_index { |byte, i| diff |= byte ^ b_bytes[i] }
+        diff.zero?
+      end
+    end
+  end
+end

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -184,33 +184,70 @@ module StreamChat
       verify_and_parse_internal(gunzip_payload(body), signature, secret)
     end
 
-    # Decode the SQS `Body` (base64, then gzip-if-magic), verify the HMAC
-    # `signature` from the `X-Signature` message attribute, and return the
+    # Decode the SQS `Body` (base64, then gzip-if-magic), optionally verify the
+    # HMAC `signature` from the `X-Signature` message attribute, and return the
     # parsed event.
+    #
+    # Stream's SQS deliveries are not signed: SQS messages ride
+    # IAM-authenticated queues, so an additional HMAC on top is redundant.
+    # `signature` and `secret` are therefore optional; pass both to opt into
+    # the legacy verification path, omit both to skip it. Passing exactly one
+    # raises `InvalidWebhookError`.
     sig do
       params(
         message_body: String,
-        signature: String,
-        secret: String
+        signature: T.nilable(String),
+        secret: T.nilable(String)
       ).returns(T::Hash[String, T.untyped])
     end
-    def self.verify_and_parse_sqs(message_body, signature, secret)
-      verify_and_parse_internal(decode_sqs_payload(message_body), signature, secret)
+    def self.verify_and_parse_sqs(message_body, signature = nil, secret = nil)
+      decoded = decode_sqs_payload(message_body)
+      verify_and_parse_optional(decoded, signature, secret, 'SQS')
     end
 
-    # Decode the SNS notification `Message` (identical to SQS handling), verify
-    # the HMAC `signature` from the `X-Signature` message attribute, and return
-    # the parsed event.
+    # Decode the SNS notification `Message` (identical to SQS handling),
+    # optionally verify the HMAC `signature` from the `X-Signature` message
+    # attribute, and return the parsed event.
+    #
+    # Stream's SNS deliveries are not signed by Stream: SNS notifications carry
+    # AWS's own SNS signature, so an additional HMAC on top is redundant.
+    # `signature` and `secret` are therefore optional; pass both to opt into
+    # the legacy verification path, omit both to skip it. Passing exactly one
+    # raises `InvalidWebhookError`.
     sig do
       params(
-        message: String,
-        signature: String,
-        secret: String
+        notification_body: String,
+        signature: T.nilable(String),
+        secret: T.nilable(String)
       ).returns(T::Hash[String, T.untyped])
     end
-    def self.verify_and_parse_sns(message, signature, secret)
-      verify_and_parse_internal(decode_sns_payload(message), signature, secret)
+    def self.verify_and_parse_sns(notification_body, signature = nil, secret = nil)
+      decoded = decode_sns_payload(notification_body)
+      verify_and_parse_optional(decoded, signature, secret, 'SNS')
     end
+
+    sig do
+      params(
+        payload: String,
+        signature: T.nilable(String),
+        secret: T.nilable(String),
+        transport: String
+      ).returns(T::Hash[String, T.untyped])
+    end
+    def self.verify_and_parse_optional(payload, signature, secret, transport)
+      has_signature = !signature.nil? && !signature.empty?
+      has_secret    = !secret.nil?    && !secret.empty?
+
+      if has_signature && has_secret
+        verify_and_parse_internal(payload, signature, secret)
+      elsif has_signature || has_secret
+        raise InvalidWebhookError,
+              "signature and secret must both be provided to verify the #{transport} payload"
+      else
+        parse_event(payload)
+      end
+    end
+    private_class_method :verify_and_parse_optional
 
     # Timing-safe equality check used to compare the locally computed HMAC
     # with the `X-Signature` header. Prefers the OpenSSL primitive when the

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -8,29 +8,17 @@ require 'sorbet-runtime'
 require 'stringio'
 require 'zlib'
 
-module StreamChat
-  # Single exception class raised by every webhook primitive when the payload
-  # cannot be decoded, decompressed, verified, or parsed. Callers only need
-  # one `rescue` arm and can branch on `message` (or the constants below) for
-  # mode-specific behaviour.
-  class InvalidWebhookError < StandardError
-    SIGNATURE_MISMATCH = T.let('signature mismatch', String)
-    INVALID_BASE64     = T.let('invalid base64 encoding', String)
-    GZIP_FAILED        = T.let('gzip decompression failed', String)
-    INVALID_JSON       = T.let('invalid JSON payload', String)
-  end
+require 'stream-chat/errors'
 
+module StreamChat
   # Stateless helpers implementing the cross-SDK webhook contract documented at
   # https://getstream.io/chat/docs/node/webhooks_overview/.
   #
-  # The composite functions (`verify_and_parse_webhook`, `verify_and_parse_sqs`,
-  # `verify_and_parse_sns`) are the recommended entry points. The primitives
-  # they compose (`gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload`,
+  # The composite functions (`verify_and_parse_webhook`, `parse_sqs`,
+  # `parse_sns`) are the recommended entry points. The primitives
+  # they compose (`ungzip_payload`, `decode_sqs_payload`, `decode_sns_payload`,
   # `verify_signature`, `parse_event`) are exposed so callers can build custom
   # flows or run individual steps in isolation.
-  #
-  # Every failure path raises `StreamChat::InvalidWebhookError`. The original
-  # underlying exception (Zlib, Base64, JSON) is preserved on `Exception#cause`.
   #
   # The Ruby SDK currently returns the parsed JSON as a `Hash`; typed event
   # classes will land in a future release.
@@ -62,14 +50,14 @@ module StreamChat
     # handler correct when middleware - Rack, Rails - auto-decompresses the
     # request before your code sees it.
     sig { params(body: T.any(String, T::Array[Integer])).returns(String) }
-    def self.gunzip_payload(body)
+    def self.ungzip_payload(body)
       raw = normalize_body(body)
       return raw unless raw.start_with?(GZIP_MAGIC)
 
       begin
         Zlib::GzipReader.new(StringIO.new(raw)).read.force_encoding(Encoding::ASCII_8BIT)
-      rescue Zlib::Error
-        raise InvalidWebhookError, InvalidWebhookError::GZIP_FAILED
+      rescue Zlib::Error => e
+        raise WebhookSignatureError, "failed to decompress gzip payload: #{e.message}"
       end
     end
 
@@ -81,10 +69,10 @@ module StreamChat
       decoded =
         begin
           Base64.strict_decode64(body)
-        rescue ArgumentError
-          raise InvalidWebhookError, InvalidWebhookError::INVALID_BASE64
+        rescue ArgumentError => e
+          raise WebhookSignatureError, "failed to base64-decode payload: #{e.message}"
         end
-      gunzip_payload(decoded)
+      ungzip_payload(decoded)
     end
 
     # Reverses an SNS HTTP notification envelope. When `notification_body` is a
@@ -93,10 +81,6 @@ module StreamChat
     # (base64-decode, then gzip-if-magic). When the input is not a JSON
     # envelope it is treated as the already-extracted `Message` string, so
     # call sites that pre-unwrap continue to work.
-    #
-    # The envelope parsing is intentionally lenient: malformed envelope JSON
-    # is silently ignored and the input falls through to the SQS pipeline,
-    # which is the path that surfaces structural errors.
     sig { params(notification_body: String).returns(String) }
     def self.decode_sns_payload(notification_body)
       inner = extract_sns_message(notification_body)
@@ -121,7 +105,7 @@ module StreamChat
     private_class_method :extract_sns_message
 
     # Constant-time HMAC-SHA256 verification of `signature` against the digest
-    # of `body` keyed by `secret`. Raises `InvalidWebhookError` on mismatch.
+    # of `body` keyed by `secret`.
     #
     # The signature is always computed over the **uncompressed** JSON bytes,
     # so callers that decoded a gzipped or base64-wrapped payload must pass
@@ -131,12 +115,12 @@ module StreamChat
         body: T.any(String, T::Array[Integer]),
         signature: String,
         secret: String
-      ).void
+      ).returns(T::Boolean)
     end
     def self.verify_signature(body, signature, secret)
       raw = normalize_body(body)
       expected = OpenSSL::HMAC.hexdigest('SHA256', secret, raw)
-      raise InvalidWebhookError, InvalidWebhookError::SIGNATURE_MISMATCH unless constant_time_equal?(expected, signature)
+      constant_time_equal?(expected, signature)
     end
 
     # Parse a JSON-encoded webhook event into a `Hash`.
@@ -147,13 +131,8 @@ module StreamChat
     # changing call sites.
     sig { params(payload: String).returns(T::Hash[String, T.untyped]) }
     def self.parse_event(payload)
-      result =
-        begin
-          JSON.parse(payload)
-        rescue JSON::ParserError
-          raise InvalidWebhookError, InvalidWebhookError::INVALID_JSON
-        end
-      raise InvalidWebhookError, InvalidWebhookError::INVALID_JSON unless result.is_a?(Hash)
+      result = JSON.parse(payload)
+      raise WebhookSignatureError, 'failed to parse webhook event: top-level value is not an object' unless result.is_a?(Hash)
 
       result
     end
@@ -166,7 +145,8 @@ module StreamChat
       ).returns(T::Hash[String, T.untyped])
     end
     def self.verify_and_parse_internal(payload, signature, secret)
-      verify_signature(payload, signature, secret)
+      raise WebhookSignatureError, 'invalid webhook signature' unless verify_signature(payload, signature, secret)
+
       parse_event(payload)
     end
     private_class_method :verify_and_parse_internal
@@ -181,73 +161,21 @@ module StreamChat
       ).returns(T::Hash[String, T.untyped])
     end
     def self.verify_and_parse_webhook(body, signature, secret)
-      verify_and_parse_internal(gunzip_payload(body), signature, secret)
+      verify_and_parse_internal(ungzip_payload(body), signature, secret)
     end
 
-    # Decode the SQS `Body` (base64, then gzip-if-magic), optionally verify the
-    # HMAC `signature` from the `X-Signature` message attribute, and return the
-    # parsed event.
-    #
-    # Stream's SQS deliveries are not signed: SQS messages ride
-    # IAM-authenticated queues, so an additional HMAC on top is redundant.
-    # `signature` and `secret` are therefore optional; pass both to opt into
-    # the legacy verification path, omit both to skip it. Passing exactly one
-    # raises `InvalidWebhookError`.
-    sig do
-      params(
-        message_body: String,
-        signature: T.nilable(String),
-        secret: T.nilable(String)
-      ).returns(T::Hash[String, T.untyped])
-    end
-    def self.verify_and_parse_sqs(message_body, signature = nil, secret = nil)
-      decoded = decode_sqs_payload(message_body)
-      verify_and_parse_optional(decoded, signature, secret, 'SQS')
+    # Decode the SQS `Body` (base64 + gzip-if-magic) and return the parsed Hash.
+    # Stream does not HMAC-sign SQS bodies.
+    sig { params(message_body: String).returns(T::Hash[String, T.untyped]) }
+    def self.parse_sqs(message_body)
+      parse_event(decode_sqs_payload(message_body))
     end
 
-    # Decode the SNS notification `Message` (identical to SQS handling),
-    # optionally verify the HMAC `signature` from the `X-Signature` message
-    # attribute, and return the parsed event.
-    #
-    # Stream's SNS deliveries are not signed by Stream: SNS notifications carry
-    # AWS's own SNS signature, so an additional HMAC on top is redundant.
-    # `signature` and `secret` are therefore optional; pass both to opt into
-    # the legacy verification path, omit both to skip it. Passing exactly one
-    # raises `InvalidWebhookError`.
-    sig do
-      params(
-        notification_body: String,
-        signature: T.nilable(String),
-        secret: T.nilable(String)
-      ).returns(T::Hash[String, T.untyped])
+    # Decode an SNS-delivered payload (unwrap envelope when needed). No HMAC.
+    sig { params(message: String).returns(T::Hash[String, T.untyped]) }
+    def self.parse_sns(message)
+      parse_event(decode_sns_payload(message))
     end
-    def self.verify_and_parse_sns(notification_body, signature = nil, secret = nil)
-      decoded = decode_sns_payload(notification_body)
-      verify_and_parse_optional(decoded, signature, secret, 'SNS')
-    end
-
-    sig do
-      params(
-        payload: String,
-        signature: T.nilable(String),
-        secret: T.nilable(String),
-        transport: String
-      ).returns(T::Hash[String, T.untyped])
-    end
-    def self.verify_and_parse_optional(payload, signature, secret, transport)
-      has_signature = !signature.nil? && !signature.empty?
-      has_secret    = !secret.nil?    && !secret.empty?
-
-      if has_signature && has_secret
-        verify_and_parse_internal(payload, signature, secret)
-      elsif has_signature || has_secret
-        raise InvalidWebhookError,
-              "signature and secret must both be provided to verify the #{transport} payload"
-      else
-        parse_event(payload)
-      end
-    end
-    private_class_method :verify_and_parse_optional
 
     # Timing-safe equality check used to compare the locally computed HMAC
     # with the `X-Signature` header. Prefers the OpenSSL primitive when the

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -16,7 +16,7 @@ module StreamChat
   #
   # The composite functions (`verify_and_parse_webhook`, `verify_and_parse_sqs`,
   # `verify_and_parse_sns`) are the recommended entry points. The primitives
-  # they compose (`ungzip_payload`, `decode_sqs_payload`, `decode_sns_payload`,
+  # they compose (`gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload`,
   # `verify_signature`, `parse_event`) are exposed so callers can build custom
   # flows or run individual steps in isolation.
   #
@@ -50,7 +50,7 @@ module StreamChat
     # handler correct when middleware - Rack, Rails - auto-decompresses the
     # request before your code sees it.
     sig { params(body: T.any(String, T::Array[Integer])).returns(String) }
-    def self.ungzip_payload(body)
+    def self.gunzip_payload(body)
       raw = normalize_body(body)
       return raw unless raw.start_with?(GZIP_MAGIC)
 
@@ -72,7 +72,7 @@ module StreamChat
         rescue ArgumentError => e
           raise WebhookSignatureError, "failed to base64-decode payload: #{e.message}"
         end
-      ungzip_payload(decoded)
+      gunzip_payload(decoded)
     end
 
     # Reverses an SNS HTTP notification envelope. When `notification_body` is a
@@ -161,7 +161,7 @@ module StreamChat
       ).returns(T::Hash[String, T.untyped])
     end
     def self.verify_and_parse_webhook(body, signature, secret)
-      verify_and_parse_internal(ungzip_payload(body), signature, secret)
+      verify_and_parse_internal(gunzip_payload(body), signature, secret)
     end
 
     # Decode the SQS `Body` (base64, then gzip-if-magic), verify the HMAC

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -8,9 +8,18 @@ require 'sorbet-runtime'
 require 'stringio'
 require 'zlib'
 
-require 'stream-chat/errors'
-
 module StreamChat
+  # Single exception class raised by every webhook primitive when the payload
+  # cannot be decoded, decompressed, verified, or parsed. Callers only need
+  # one `rescue` arm and can branch on `message` (or the constants below) for
+  # mode-specific behaviour.
+  class InvalidWebhookError < StandardError
+    SIGNATURE_MISMATCH = T.let('signature mismatch', String)
+    INVALID_BASE64     = T.let('invalid base64 encoding', String)
+    GZIP_FAILED        = T.let('gzip decompression failed', String)
+    INVALID_JSON       = T.let('invalid JSON payload', String)
+  end
+
   # Stateless helpers implementing the cross-SDK webhook contract documented at
   # https://getstream.io/chat/docs/node/webhooks_overview/.
   #
@@ -19,6 +28,9 @@ module StreamChat
   # they compose (`gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload`,
   # `verify_signature`, `parse_event`) are exposed so callers can build custom
   # flows or run individual steps in isolation.
+  #
+  # Every failure path raises `StreamChat::InvalidWebhookError`. The original
+  # underlying exception (Zlib, Base64, JSON) is preserved on `Exception#cause`.
   #
   # The Ruby SDK currently returns the parsed JSON as a `Hash`; typed event
   # classes will land in a future release.
@@ -56,8 +68,8 @@ module StreamChat
 
       begin
         Zlib::GzipReader.new(StringIO.new(raw)).read.force_encoding(Encoding::ASCII_8BIT)
-      rescue Zlib::Error => e
-        raise WebhookSignatureError, "failed to decompress gzip payload: #{e.message}"
+      rescue Zlib::Error
+        raise InvalidWebhookError, InvalidWebhookError::GZIP_FAILED
       end
     end
 
@@ -69,8 +81,8 @@ module StreamChat
       decoded =
         begin
           Base64.strict_decode64(body)
-        rescue ArgumentError => e
-          raise WebhookSignatureError, "failed to base64-decode payload: #{e.message}"
+        rescue ArgumentError
+          raise InvalidWebhookError, InvalidWebhookError::INVALID_BASE64
         end
       gunzip_payload(decoded)
     end
@@ -81,6 +93,10 @@ module StreamChat
     # (base64-decode, then gzip-if-magic). When the input is not a JSON
     # envelope it is treated as the already-extracted `Message` string, so
     # call sites that pre-unwrap continue to work.
+    #
+    # The envelope parsing is intentionally lenient: malformed envelope JSON
+    # is silently ignored and the input falls through to the SQS pipeline,
+    # which is the path that surfaces structural errors.
     sig { params(notification_body: String).returns(String) }
     def self.decode_sns_payload(notification_body)
       inner = extract_sns_message(notification_body)
@@ -105,7 +121,7 @@ module StreamChat
     private_class_method :extract_sns_message
 
     # Constant-time HMAC-SHA256 verification of `signature` against the digest
-    # of `body` keyed by `secret`.
+    # of `body` keyed by `secret`. Raises `InvalidWebhookError` on mismatch.
     #
     # The signature is always computed over the **uncompressed** JSON bytes,
     # so callers that decoded a gzipped or base64-wrapped payload must pass
@@ -115,12 +131,12 @@ module StreamChat
         body: T.any(String, T::Array[Integer]),
         signature: String,
         secret: String
-      ).returns(T::Boolean)
+      ).void
     end
     def self.verify_signature(body, signature, secret)
       raw = normalize_body(body)
       expected = OpenSSL::HMAC.hexdigest('SHA256', secret, raw)
-      constant_time_equal?(expected, signature)
+      raise InvalidWebhookError, InvalidWebhookError::SIGNATURE_MISMATCH unless constant_time_equal?(expected, signature)
     end
 
     # Parse a JSON-encoded webhook event into a `Hash`.
@@ -131,8 +147,13 @@ module StreamChat
     # changing call sites.
     sig { params(payload: String).returns(T::Hash[String, T.untyped]) }
     def self.parse_event(payload)
-      result = JSON.parse(payload)
-      raise WebhookSignatureError, 'failed to parse webhook event: top-level value is not an object' unless result.is_a?(Hash)
+      result =
+        begin
+          JSON.parse(payload)
+        rescue JSON::ParserError
+          raise InvalidWebhookError, InvalidWebhookError::INVALID_JSON
+        end
+      raise InvalidWebhookError, InvalidWebhookError::INVALID_JSON unless result.is_a?(Hash)
 
       result
     end
@@ -145,8 +166,7 @@ module StreamChat
       ).returns(T::Hash[String, T.untyped])
     end
     def self.verify_and_parse_internal(payload, signature, secret)
-      raise WebhookSignatureError, 'invalid webhook signature' unless verify_signature(payload, signature, secret)
-
+      verify_signature(payload, signature, secret)
       parse_event(payload)
     end
     private_class_method :verify_and_parse_internal

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -75,12 +75,34 @@ module StreamChat
       ungzip_payload(decoded)
     end
 
-    # Identical to `decode_sqs_payload`; exposed under both names so call sites
-    # read intent.
-    sig { params(message: String).returns(String) }
-    def self.decode_sns_payload(message)
-      decode_sqs_payload(message)
+    # Reverses an SNS HTTP notification envelope. When `notification_body` is a
+    # JSON envelope (`{"Type":"Notification","Message":"..."}`), the inner
+    # `Message` field is extracted and run through the SQS pipeline
+    # (base64-decode, then gzip-if-magic). When the input is not a JSON
+    # envelope it is treated as the already-extracted `Message` string, so
+    # call sites that pre-unwrap continue to work.
+    sig { params(notification_body: String).returns(String) }
+    def self.decode_sns_payload(notification_body)
+      inner = extract_sns_message(notification_body)
+      decode_sqs_payload(inner.nil? ? notification_body : inner)
     end
+
+    sig { params(notification_body: String).returns(T.nilable(String)) }
+    def self.extract_sns_message(notification_body)
+      trimmed = notification_body.to_s.lstrip
+      return nil unless trimmed.start_with?('{')
+
+      begin
+        parsed = JSON.parse(trimmed)
+      rescue JSON::ParserError
+        return nil
+      end
+      return nil unless parsed.is_a?(Hash)
+
+      message = parsed['Message']
+      message.is_a?(String) ? message : nil
+    end
+    private_class_method :extract_sns_message
 
     # Constant-time HMAC-SHA256 verification of `signature` against the digest
     # of `body` keyed by `secret`.

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -164,14 +164,14 @@ module StreamChat
       verify_and_parse_internal(ungzip_payload(body), signature, secret)
     end
 
-    # Decode the SQS `Body` (base64 + gzip-if-magic) and return the parsed Hash.
-    # Stream does not HMAC-sign SQS bodies.
+    # Decode the SQS `Body` (base64, then gzip-if-magic) and return the parsed
+    # event JSON. Stream does not ship an application-level signature on SQS payloads.
     sig { params(message_body: String).returns(T::Hash[String, T.untyped]) }
     def self.parse_sqs(message_body)
       parse_event(decode_sqs_payload(message_body))
     end
 
-    # Decode an SNS-delivered payload (unwrap envelope when needed). No HMAC.
+    # Decode SNS (unwrap envelope when needed) and return the parsed event JSON.
     sig { params(message: String).returns(T::Hash[String, T.untyped]) }
     def self.parse_sns(message)
       parse_event(decode_sns_payload(message))

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -16,7 +16,7 @@ module StreamChat
   #
   # The composite functions (`verify_and_parse_webhook`, `parse_sqs`,
   # `parse_sns`) are the recommended entry points. The primitives
-  # they compose (`ungzip_payload`, `decode_sqs_payload`, `decode_sns_payload`,
+  # they compose (`gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload`,
   # `verify_signature`, `parse_event`) are exposed so callers can build custom
   # flows or run individual steps in isolation.
   #
@@ -50,14 +50,14 @@ module StreamChat
     # handler correct when middleware - Rack, Rails - auto-decompresses the
     # request before your code sees it.
     sig { params(body: T.any(String, T::Array[Integer])).returns(String) }
-    def self.ungzip_payload(body)
+    def self.gunzip_payload(body)
       raw = normalize_body(body)
       return raw unless raw.start_with?(GZIP_MAGIC)
 
       begin
         Zlib::GzipReader.new(StringIO.new(raw)).read.force_encoding(Encoding::ASCII_8BIT)
-      rescue Zlib::Error => e
-        raise WebhookSignatureError, "failed to decompress gzip payload: #{e.message}"
+      rescue Zlib::Error
+        raise InvalidWebhookError, InvalidWebhookError::GZIP_FAILED
       end
     end
 
@@ -69,10 +69,10 @@ module StreamChat
       decoded =
         begin
           Base64.strict_decode64(body)
-        rescue ArgumentError => e
-          raise WebhookSignatureError, "failed to base64-decode payload: #{e.message}"
+        rescue ArgumentError
+          raise InvalidWebhookError, InvalidWebhookError::INVALID_BASE64
         end
-      ungzip_payload(decoded)
+      gunzip_payload(decoded)
     end
 
     # Reverses an SNS HTTP notification envelope. When `notification_body` is a
@@ -131,8 +131,13 @@ module StreamChat
     # changing call sites.
     sig { params(payload: String).returns(T::Hash[String, T.untyped]) }
     def self.parse_event(payload)
-      result = JSON.parse(payload)
-      raise WebhookSignatureError, 'failed to parse webhook event: top-level value is not an object' unless result.is_a?(Hash)
+      result =
+        begin
+          JSON.parse(payload)
+        rescue JSON::ParserError
+          raise InvalidWebhookError, InvalidWebhookError::INVALID_JSON
+        end
+      raise InvalidWebhookError, InvalidWebhookError::INVALID_JSON unless result.is_a?(Hash)
 
       result
     end
@@ -145,7 +150,7 @@ module StreamChat
       ).returns(T::Hash[String, T.untyped])
     end
     def self.verify_and_parse_internal(payload, signature, secret)
-      raise WebhookSignatureError, 'invalid webhook signature' unless verify_signature(payload, signature, secret)
+      raise InvalidWebhookError, InvalidWebhookError::SIGNATURE_MISMATCH unless verify_signature(payload, signature, secret)
 
       parse_event(payload)
     end
@@ -161,7 +166,7 @@ module StreamChat
       ).returns(T::Hash[String, T.untyped])
     end
     def self.verify_and_parse_webhook(body, signature, secret)
-      verify_and_parse_internal(ungzip_payload(body), signature, secret)
+      verify_and_parse_internal(gunzip_payload(body), signature, secret)
     end
 
     # Decode the SQS `Body` (base64, then gzip-if-magic) and return the parsed

--- a/lib/stream-chat/webhook.rb
+++ b/lib/stream-chat/webhook.rb
@@ -25,7 +25,7 @@ module StreamChat
   module Webhook # rubocop:disable Metrics/ModuleLength
     extend T::Sig
 
-    GZIP_MAGIC = T.let("\x1f\x8b\x08".b.freeze, String)
+    GZIP_MAGIC = T.let("\x1f\x8b".b.freeze, String)
 
     # Coerces the webhook body into a binary `String` regardless of whether
     # the caller hands us a `String` (HTTP `request.raw_post`) or an array of
@@ -43,8 +43,8 @@ module StreamChat
     end
 
     # Returns `body` unchanged unless it starts with the gzip magic
-    # (`1f 8b 08`), in which case the gzip stream is inflated and the
-    # decompressed bytes are returned.
+    # (`1f 8b`, per RFC 1952), in which case the gzip stream is inflated and
+    # the decompressed bytes are returned.
     #
     # Magic-byte detection (rather than relying on a header) keeps the same
     # handler correct when middleware - Rack, Rails - auto-decompresses the

--- a/spec/webhook_compression_spec.rb
+++ b/spec/webhook_compression_spec.rb
@@ -25,6 +25,20 @@ describe 'StreamChat webhook verification + parsing' do
     OpenSSL::HMAC.hexdigest('SHA256', secret, data)
   end
 
+  def sns_envelope(inner_message)
+    JSON.generate({
+                    'Type' => 'Notification',
+                    'MessageId' => '22b80b92-fdea-4c2c-8f9d-bdfb0c7bf324',
+                    'TopicArn' => 'arn:aws:sns:us-east-1:123456789012:stream-webhooks',
+                    'Message' => inner_message,
+                    'Timestamp' => '2026-05-11T10:00:00.000Z',
+                    'SignatureVersion' => '1',
+                    'MessageAttributes' => {
+                      'X-Signature' => { 'Type' => 'String', 'Value' => '<signature placeholder>' }
+                    }
+                  })
+  end
+
   let(:client) { StreamChat::Client.new(api_key, api_secret) }
 
   describe 'StreamChat::Webhook.ungzip_payload' do
@@ -73,10 +87,22 @@ describe 'StreamChat webhook verification + parsing' do
   end
 
   describe 'StreamChat::Webhook.decode_sns_payload' do
-    it 'aliases decode_sqs_payload' do
+    it 'treats a pre-extracted Message identically to decode_sqs_payload' do
       wrapped = Base64.strict_encode64(gzip(json_body))
       expect(StreamChat::Webhook.decode_sns_payload(wrapped))
         .to eq(StreamChat::Webhook.decode_sqs_payload(wrapped))
+    end
+
+    it 'unwraps a full SNS HTTP notification envelope' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      envelope = sns_envelope(wrapped)
+      expect(StreamChat::Webhook.decode_sns_payload(envelope)).to eq(json_body)
+    end
+
+    it 'handles whitespace before the envelope JSON' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      envelope = "\n  #{sns_envelope(wrapped)}"
+      expect(StreamChat::Webhook.decode_sns_payload(envelope)).to eq(json_body)
     end
   end
 
@@ -174,17 +200,32 @@ describe 'StreamChat webhook verification + parsing' do
   end
 
   describe '#verify_and_parse_sns' do
-    it 'parses a base64 + gzip notification' do
+    it 'parses a pre-extracted base64 + gzip notification' do
       wrapped = Base64.strict_encode64(gzip(json_body))
       sig = hmac_hex(api_secret, json_body)
       expect(client.verify_and_parse_sns(wrapped, sig)).to eq(event_hash)
     end
 
-    it 'returns the same event as verify_and_parse_sqs' do
+    it 'returns the same event as verify_and_parse_sqs for pre-extracted Message' do
       wrapped = Base64.strict_encode64(gzip(json_body))
       sig = hmac_hex(api_secret, json_body)
       expect(client.verify_and_parse_sns(wrapped, sig))
         .to eq(client.verify_and_parse_sqs(wrapped, sig))
+    end
+
+    it 'parses a full SNS HTTP notification envelope' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      envelope = sns_envelope(wrapped)
+      sig = hmac_hex(api_secret, json_body)
+      expect(client.verify_and_parse_sns(envelope, sig)).to eq(event_hash)
+    end
+
+    it 'rejects signature computed over the envelope JSON, not the payload' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      envelope = sns_envelope(wrapped)
+      sig_over_envelope = hmac_hex(api_secret, envelope)
+      expect { client.verify_and_parse_sns(envelope, sig_over_envelope) }
+        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
     end
   end
 end

--- a/spec/webhook_compression_spec.rb
+++ b/spec/webhook_compression_spec.rb
@@ -41,31 +41,36 @@ describe 'StreamChat webhook verification + parsing' do
 
   let(:client) { StreamChat::Client.new(api_key, api_secret) }
 
-  describe 'StreamChat::Webhook.ungzip_payload' do
+  describe 'StreamChat::Webhook.gunzip_payload' do
     it 'passes through plain bytes unchanged' do
-      expect(StreamChat::Webhook.ungzip_payload(json_body)).to eq(json_body)
+      expect(StreamChat::Webhook.gunzip_payload(json_body)).to eq(json_body)
     end
 
     it 'inflates gzip-magic bytes' do
-      expect(StreamChat::Webhook.ungzip_payload(gzip(json_body))).to eq(json_body)
+      expect(StreamChat::Webhook.gunzip_payload(gzip(json_body))).to eq(json_body)
     end
 
     it 'accepts a body provided as an array of integers' do
-      expect(StreamChat::Webhook.ungzip_payload(json_body.bytes)).to eq(json_body)
+      expect(StreamChat::Webhook.gunzip_payload(json_body.bytes)).to eq(json_body)
     end
 
     it 'returns empty input unchanged' do
-      expect(StreamChat::Webhook.ungzip_payload('')).to eq('')
+      expect(StreamChat::Webhook.gunzip_payload('')).to eq('')
     end
 
     it 'returns short input below magic length unchanged' do
-      expect(StreamChat::Webhook.ungzip_payload('ab')).to eq('ab')
+      expect(StreamChat::Webhook.gunzip_payload('ab')).to eq('ab')
     end
 
     it 'raises on truncated gzip with magic' do
       bad = "\x1f\x8b\x08\x00\x00\x00".b
-      expect { StreamChat::Webhook.ungzip_payload(bad) }
+      expect { StreamChat::Webhook.gunzip_payload(bad) }
         .to raise_error(StreamChat::WebhookSignatureError, /decompress gzip/i)
+    end
+
+    it 'decompresses the helloworld fixture' do
+      expect(StreamChat::Webhook.gunzip_payload(Base64.decode64('H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA')))
+        .to eq('helloworld')
     end
   end
 
@@ -83,6 +88,15 @@ describe 'StreamChat webhook verification + parsing' do
     it 'raises on invalid base64' do
       expect { StreamChat::Webhook.decode_sqs_payload('!!!not-base64!!!') }
         .to raise_error(StreamChat::WebhookSignatureError, /base64-decode/i)
+    end
+
+    it 'decodes the helloworld base64 fixture' do
+      expect(StreamChat::Webhook.decode_sqs_payload('aGVsbG93b3JsZA==')).to eq('helloworld')
+    end
+
+    it 'decodes the helloworld base64+gzip fixture' do
+      expect(StreamChat::Webhook.decode_sqs_payload('H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA'))
+        .to eq('helloworld')
     end
   end
 

--- a/spec/webhook_compression_spec.rb
+++ b/spec/webhook_compression_spec.rb
@@ -62,10 +62,10 @@ describe 'StreamChat webhook verification + parsing' do
       expect(StreamChat::Webhook.gunzip_payload('ab')).to eq('ab')
     end
 
-    it 'raises on truncated gzip with magic' do
+    it 'raises InvalidWebhookError on truncated gzip with magic' do
       bad = "\x1f\x8b\x08\x00\x00\x00".b
       expect { StreamChat::Webhook.gunzip_payload(bad) }
-        .to raise_error(StreamChat::WebhookSignatureError, /decompress gzip/i)
+        .to raise_error(StreamChat::InvalidWebhookError, /gzip decompression failed/)
     end
 
     it 'decompresses the helloworld fixture' do
@@ -85,9 +85,9 @@ describe 'StreamChat webhook verification + parsing' do
       expect(StreamChat::Webhook.decode_sqs_payload(wrapped)).to eq(json_body)
     end
 
-    it 'raises on invalid base64' do
+    it 'raises InvalidWebhookError on invalid base64' do
       expect { StreamChat::Webhook.decode_sqs_payload('!!!not-base64!!!') }
-        .to raise_error(StreamChat::WebhookSignatureError, /base64-decode/i)
+        .to raise_error(StreamChat::InvalidWebhookError, /invalid base64 encoding/)
     end
 
     it 'decodes the helloworld base64 fixture' do
@@ -121,19 +121,21 @@ describe 'StreamChat webhook verification + parsing' do
   end
 
   describe 'StreamChat::Webhook.verify_signature' do
-    it 'returns true for matching HMAC' do
+    it 'does not raise for a matching HMAC' do
       sig = hmac_hex(api_secret, json_body)
-      expect(StreamChat::Webhook.verify_signature(json_body, sig, api_secret)).to be true
+      expect { StreamChat::Webhook.verify_signature(json_body, sig, api_secret) }.not_to raise_error
     end
 
-    it 'returns false for mismatched signature' do
-      expect(StreamChat::Webhook.verify_signature(json_body, '0' * 64, api_secret)).to be false
+    it 'raises InvalidWebhookError for a mismatched signature' do
+      expect { StreamChat::Webhook.verify_signature(json_body, '0' * 64, api_secret) }
+        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
     end
 
-    it 'rejects signatures computed over compressed bytes' do
+    it 'raises when the signature was computed over compressed bytes' do
       compressed = gzip(json_body)
       sig_over_compressed = hmac_hex(api_secret, compressed)
-      expect(StreamChat::Webhook.verify_signature(json_body, sig_over_compressed, api_secret)).to be false
+      expect { StreamChat::Webhook.verify_signature(json_body, sig_over_compressed, api_secret) }
+        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
     end
   end
 
@@ -147,8 +149,9 @@ describe 'StreamChat webhook verification + parsing' do
         .to eq({ 'type' => 'a.future.event', 'custom' => 42 })
     end
 
-    it 'raises on malformed JSON' do
-      expect { StreamChat::Webhook.parse_event('not json') }.to raise_error(JSON::ParserError)
+    it 'raises InvalidWebhookError on malformed JSON' do
+      expect { StreamChat::Webhook.parse_event('not json') }
+        .to raise_error(StreamChat::InvalidWebhookError, /invalid JSON payload/)
     end
   end
 
@@ -179,16 +182,16 @@ describe 'StreamChat webhook verification + parsing' do
       expect(client.verify_and_parse_webhook(json_body.bytes, sig)).to eq(event_hash)
     end
 
-    it 'raises WebhookSignatureError on signature mismatch' do
+    it 'raises InvalidWebhookError on signature mismatch' do
       expect { client.verify_and_parse_webhook(json_body, 'definitely-wrong') }
-        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
     end
 
     it 'rejects a gzip body when the signature was computed over compressed bytes' do
       compressed = gzip(json_body)
       sig_over_compressed = hmac_hex(api_secret, compressed)
       expect { client.verify_and_parse_webhook(compressed, sig_over_compressed) }
-        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
     end
   end
 
@@ -209,7 +212,7 @@ describe 'StreamChat webhook verification + parsing' do
       wrapped = Base64.strict_encode64(gzip(json_body))
       sig_over_wrapped = hmac_hex(api_secret, wrapped)
       expect { client.verify_and_parse_sqs(wrapped, sig_over_wrapped) }
-        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
     end
   end
 
@@ -239,7 +242,25 @@ describe 'StreamChat webhook verification + parsing' do
       envelope = sns_envelope(wrapped)
       sig_over_envelope = hmac_hex(api_secret, envelope)
       expect { client.verify_and_parse_sns(envelope, sig_over_envelope) }
-        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
+    end
+  end
+
+  describe 'StreamChat::InvalidWebhookError consolidation' do
+    it 'raises InvalidWebhookError on invalid base64' do
+      expect { StreamChat::Webhook.decode_sqs_payload('!!!not-base64!!!') }
+        .to raise_error(StreamChat::InvalidWebhookError, /invalid base64 encoding/)
+    end
+
+    it 'raises InvalidWebhookError on corrupt gzip' do
+      bad = "\x1f\x8b\x08\x00\x00\x00".b
+      expect { StreamChat::Webhook.gunzip_payload(bad) }
+        .to raise_error(StreamChat::InvalidWebhookError, /gzip decompression failed/)
+    end
+
+    it 'raises InvalidWebhookError on invalid JSON' do
+      expect { StreamChat::Webhook.parse_event('not json') }
+        .to raise_error(StreamChat::InvalidWebhookError, /invalid JSON payload/)
     end
   end
 end

--- a/spec/webhook_compression_spec.rb
+++ b/spec/webhook_compression_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'openssl'
+require 'stringio'
+require 'zlib'
+
+require 'stream-chat'
+
+describe 'StreamChat webhook compression' do
+  let(:json_body) { '{"type":"message.new","message":{"text":"the quick brown fox"}}' }
+  let(:api_key)    { 'tkey' }
+  let(:api_secret) { 'tsec2' }
+
+  def gzip(bytes)
+    io = StringIO.new
+    io.set_encoding(Encoding::ASCII_8BIT)
+    Zlib::GzipWriter.wrap(io) { |gz| gz.write(bytes) }
+    io.string
+  end
+
+  def hmac_hex(secret, data)
+    OpenSSL::HMAC.hexdigest('SHA256', secret, data)
+  end
+
+  let(:client) { StreamChat::Client.new(api_key, api_secret) }
+
+  describe '#verify_webhook (existing helper, must remain backwards compatible)' do
+    it 'returns true when the signature matches the raw body' do
+      signature = hmac_hex(api_secret, json_body)
+      expect(client.verify_webhook(json_body, signature)).to be true
+    end
+
+    it 'returns false when the signature does not match' do
+      expect(client.verify_webhook(json_body, 'not-a-real-signature')).to be false
+    end
+  end
+
+  describe '#decompress_webhook_body' do
+    context 'when both encodings are nil or empty' do
+      it 'returns the body unchanged when encodings are nil' do
+        expect(client.decompress_webhook_body(json_body, nil, nil)).to eq(json_body)
+      end
+
+      it 'returns the body unchanged when encodings are empty strings' do
+        expect(client.decompress_webhook_body(json_body, '', '')).to eq(json_body)
+      end
+
+      it 'returns the body unchanged when encodings are whitespace' do
+        expect(client.decompress_webhook_body(json_body, '   ', '   ')).to eq(json_body)
+      end
+
+      it 'accepts a body provided as an array of integers (byte array)' do
+        bytes = json_body.bytes
+        expect(client.decompress_webhook_body(bytes, nil, nil)).to eq(json_body)
+      end
+    end
+
+    context 'gzip round-trip' do
+      it 'decompresses a gzip-compressed body' do
+        compressed = gzip(json_body)
+        expect(client.decompress_webhook_body(compressed, 'gzip', nil)).to eq(json_body)
+      end
+
+      it 'is case-insensitive for the content_encoding value' do
+        compressed = gzip(json_body)
+        expect(client.decompress_webhook_body(compressed, 'GZIP', nil)).to eq(json_body)
+        expect(client.decompress_webhook_body(compressed, '  Gzip  ', nil)).to eq(json_body)
+      end
+    end
+
+    context 'base64 round-trip' do
+      it 'decodes a strict-base64 wrapped body' do
+        wrapped = Base64.strict_encode64(json_body)
+        expect(client.decompress_webhook_body(wrapped, nil, 'base64')).to eq(json_body)
+      end
+
+      it 'accepts the b64 alias' do
+        wrapped = Base64.strict_encode64(json_body)
+        expect(client.decompress_webhook_body(wrapped, nil, 'b64')).to eq(json_body)
+      end
+
+      it 'is case-insensitive for the payload_encoding value' do
+        wrapped = Base64.strict_encode64(json_body)
+        expect(client.decompress_webhook_body(wrapped, nil, 'BASE64')).to eq(json_body)
+        expect(client.decompress_webhook_body(wrapped, nil, '  Base64  ')).to eq(json_body)
+      end
+    end
+
+    context 'base64 + gzip round-trip (SQS / SNS firehose shape)' do
+      it 'decodes the base64 wrapper and then decompresses the gzip body' do
+        wrapped = Base64.strict_encode64(gzip(json_body))
+        expect(client.decompress_webhook_body(wrapped, 'gzip', 'base64')).to eq(json_body)
+      end
+    end
+
+    context 'unsupported encodings' do
+      %w[br brotli zstd deflate compress lz4].each do |unsupported|
+        it "rejects content_encoding=#{unsupported.inspect}" do
+          expect { client.decompress_webhook_body(json_body, unsupported, nil) }
+            .to raise_error(StreamChat::WebhookSignatureError, /unsupported webhook Content-Encoding/i)
+        end
+      end
+
+      %w[hex url binary].each do |unsupported|
+        it "rejects payload_encoding=#{unsupported.inspect}" do
+          expect { client.decompress_webhook_body(json_body, nil, unsupported) }
+            .to raise_error(StreamChat::WebhookSignatureError, /unsupported webhook payload_encoding/i)
+        end
+      end
+    end
+
+    context 'malformed payloads' do
+      it 'raises when the gzip bytes are corrupt' do
+        expect { client.decompress_webhook_body('not-actually-gzip', 'gzip', nil) }
+          .to raise_error(StreamChat::WebhookSignatureError, /failed to decompress webhook body/i)
+      end
+
+      it 'raises on invalid base64 input' do
+        expect { client.decompress_webhook_body("\x00\x01\xff not base64", nil, 'base64') }
+          .to raise_error(StreamChat::WebhookSignatureError, /payload_encoding=base64/i)
+      end
+    end
+  end
+
+  describe '#verify_and_decode_webhook' do
+    context 'happy paths' do
+      it 'verifies and returns the body for a plain HTTP webhook' do
+        signature = hmac_hex(api_secret, json_body)
+        expect(client.verify_and_decode_webhook(json_body, signature, nil, nil)).to eq(json_body)
+      end
+
+      it 'verifies and returns the body for a gzip-compressed webhook (signature over uncompressed bytes)' do
+        compressed = gzip(json_body)
+        signature = hmac_hex(api_secret, json_body)
+        expect(client.verify_and_decode_webhook(compressed, signature, 'gzip', nil)).to eq(json_body)
+      end
+
+      it 'verifies and returns the body for a base64+gzip SQS / SNS webhook (signature over uncompressed bytes)' do
+        wrapped = Base64.strict_encode64(gzip(json_body))
+        signature = hmac_hex(api_secret, json_body)
+        expect(client.verify_and_decode_webhook(wrapped, signature, 'gzip', 'base64')).to eq(json_body)
+      end
+    end
+
+    context 'signature mismatches' do
+      it 'raises WebhookSignatureError when the signature is wrong' do
+        expect { client.verify_and_decode_webhook(json_body, 'definitely-wrong', nil, nil) }
+          .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+      end
+
+      it 'rejects a gzip body when the signature was computed over the compressed bytes (not the JSON)' do
+        compressed = gzip(json_body)
+        wrong_signature_over_compressed = hmac_hex(api_secret, compressed)
+        expect { client.verify_and_decode_webhook(compressed, wrong_signature_over_compressed, 'gzip', nil) }
+          .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+      end
+
+      it 'rejects a base64+gzip body when the signature was computed over the wrapped bytes (not the JSON)' do
+        wrapped = Base64.strict_encode64(gzip(json_body))
+        wrong_signature_over_wrapped = hmac_hex(api_secret, wrapped)
+        expect { client.verify_and_decode_webhook(wrapped, wrong_signature_over_wrapped, 'gzip', 'base64') }
+          .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+      end
+    end
+  end
+end

--- a/spec/webhook_compression_spec.rb
+++ b/spec/webhook_compression_spec.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 require 'base64'
+require 'json'
 require 'openssl'
 require 'stringio'
 require 'zlib'
 
 require 'stream-chat'
 
-describe 'StreamChat webhook compression' do
+describe 'StreamChat webhook verification + parsing' do
   let(:json_body) { '{"type":"message.new","message":{"text":"the quick brown fox"}}' }
+  let(:event_hash) { { 'type' => 'message.new', 'message' => { 'text' => 'the quick brown fox' } } }
   let(:api_key)    { 'tkey' }
   let(:api_secret) { 'tsec2' }
 
@@ -25,10 +27,94 @@ describe 'StreamChat webhook compression' do
 
   let(:client) { StreamChat::Client.new(api_key, api_secret) }
 
-  describe '#verify_webhook (existing helper, must remain backwards compatible)' do
+  describe 'StreamChat::Webhook.ungzip_payload' do
+    it 'passes through plain bytes unchanged' do
+      expect(StreamChat::Webhook.ungzip_payload(json_body)).to eq(json_body)
+    end
+
+    it 'inflates gzip-magic bytes' do
+      expect(StreamChat::Webhook.ungzip_payload(gzip(json_body))).to eq(json_body)
+    end
+
+    it 'accepts a body provided as an array of integers' do
+      expect(StreamChat::Webhook.ungzip_payload(json_body.bytes)).to eq(json_body)
+    end
+
+    it 'returns empty input unchanged' do
+      expect(StreamChat::Webhook.ungzip_payload('')).to eq('')
+    end
+
+    it 'returns short input below magic length unchanged' do
+      expect(StreamChat::Webhook.ungzip_payload('ab')).to eq('ab')
+    end
+
+    it 'raises on truncated gzip with magic' do
+      bad = "\x1f\x8b\x08\x00\x00\x00".b
+      expect { StreamChat::Webhook.ungzip_payload(bad) }
+        .to raise_error(StreamChat::WebhookSignatureError, /decompress gzip/i)
+    end
+  end
+
+  describe 'StreamChat::Webhook.decode_sqs_payload' do
+    it 'decodes base64 only (no compression)' do
+      wrapped = Base64.strict_encode64(json_body)
+      expect(StreamChat::Webhook.decode_sqs_payload(wrapped)).to eq(json_body)
+    end
+
+    it 'decodes base64 + gzip' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      expect(StreamChat::Webhook.decode_sqs_payload(wrapped)).to eq(json_body)
+    end
+
+    it 'raises on invalid base64' do
+      expect { StreamChat::Webhook.decode_sqs_payload('!!!not-base64!!!') }
+        .to raise_error(StreamChat::WebhookSignatureError, /base64-decode/i)
+    end
+  end
+
+  describe 'StreamChat::Webhook.decode_sns_payload' do
+    it 'aliases decode_sqs_payload' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      expect(StreamChat::Webhook.decode_sns_payload(wrapped))
+        .to eq(StreamChat::Webhook.decode_sqs_payload(wrapped))
+    end
+  end
+
+  describe 'StreamChat::Webhook.verify_signature' do
+    it 'returns true for matching HMAC' do
+      sig = hmac_hex(api_secret, json_body)
+      expect(StreamChat::Webhook.verify_signature(json_body, sig, api_secret)).to be true
+    end
+
+    it 'returns false for mismatched signature' do
+      expect(StreamChat::Webhook.verify_signature(json_body, '0' * 64, api_secret)).to be false
+    end
+
+    it 'rejects signatures computed over compressed bytes' do
+      compressed = gzip(json_body)
+      sig_over_compressed = hmac_hex(api_secret, compressed)
+      expect(StreamChat::Webhook.verify_signature(json_body, sig_over_compressed, api_secret)).to be false
+    end
+  end
+
+  describe 'StreamChat::Webhook.parse_event' do
+    it 'parses a known event type into a hash' do
+      expect(StreamChat::Webhook.parse_event(json_body)).to eq(event_hash)
+    end
+
+    it 'still parses unknown event types' do
+      expect(StreamChat::Webhook.parse_event('{"type":"a.future.event","custom":42}'))
+        .to eq({ 'type' => 'a.future.event', 'custom' => 42 })
+    end
+
+    it 'raises on malformed JSON' do
+      expect { StreamChat::Webhook.parse_event('not json') }.to raise_error(JSON::ParserError)
+    end
+  end
+
+  describe '#verify_webhook (legacy boolean helper, unchanged)' do
     it 'returns true when the signature matches the raw body' do
-      signature = hmac_hex(api_secret, json_body)
-      expect(client.verify_webhook(json_body, signature)).to be true
+      expect(client.verify_webhook(json_body, hmac_hex(api_secret, json_body))).to be true
     end
 
     it 'returns false when the signature does not match' do
@@ -36,132 +122,69 @@ describe 'StreamChat webhook compression' do
     end
   end
 
-  describe '#decompress_webhook_body' do
-    context 'when both encodings are nil or empty' do
-      it 'returns the body unchanged when encodings are nil' do
-        expect(client.decompress_webhook_body(json_body, nil, nil)).to eq(json_body)
-      end
-
-      it 'returns the body unchanged when encodings are empty strings' do
-        expect(client.decompress_webhook_body(json_body, '', '')).to eq(json_body)
-      end
-
-      it 'returns the body unchanged when encodings are whitespace' do
-        expect(client.decompress_webhook_body(json_body, '   ', '   ')).to eq(json_body)
-      end
-
-      it 'accepts a body provided as an array of integers (byte array)' do
-        bytes = json_body.bytes
-        expect(client.decompress_webhook_body(bytes, nil, nil)).to eq(json_body)
-      end
+  describe '#verify_and_parse_webhook' do
+    it 'parses a plain JSON body with a valid signature' do
+      sig = hmac_hex(api_secret, json_body)
+      expect(client.verify_and_parse_webhook(json_body, sig)).to eq(event_hash)
     end
 
-    context 'gzip round-trip' do
-      it 'decompresses a gzip-compressed body' do
-        compressed = gzip(json_body)
-        expect(client.decompress_webhook_body(compressed, 'gzip', nil)).to eq(json_body)
-      end
-
-      it 'is case-insensitive for the content_encoding value' do
-        compressed = gzip(json_body)
-        expect(client.decompress_webhook_body(compressed, 'GZIP', nil)).to eq(json_body)
-        expect(client.decompress_webhook_body(compressed, '  Gzip  ', nil)).to eq(json_body)
-      end
+    it 'parses a gzip-compressed body' do
+      compressed = gzip(json_body)
+      sig = hmac_hex(api_secret, json_body)
+      expect(client.verify_and_parse_webhook(compressed, sig)).to eq(event_hash)
     end
 
-    context 'base64 round-trip' do
-      it 'decodes a strict-base64 wrapped body' do
-        wrapped = Base64.strict_encode64(json_body)
-        expect(client.decompress_webhook_body(wrapped, nil, 'base64')).to eq(json_body)
-      end
-
-      it 'accepts the b64 alias' do
-        wrapped = Base64.strict_encode64(json_body)
-        expect(client.decompress_webhook_body(wrapped, nil, 'b64')).to eq(json_body)
-      end
-
-      it 'is case-insensitive for the payload_encoding value' do
-        wrapped = Base64.strict_encode64(json_body)
-        expect(client.decompress_webhook_body(wrapped, nil, 'BASE64')).to eq(json_body)
-        expect(client.decompress_webhook_body(wrapped, nil, '  Base64  ')).to eq(json_body)
-      end
+    it 'accepts a body provided as an array of integers' do
+      sig = hmac_hex(api_secret, json_body)
+      expect(client.verify_and_parse_webhook(json_body.bytes, sig)).to eq(event_hash)
     end
 
-    context 'base64 + gzip round-trip (SQS / SNS firehose shape)' do
-      it 'decodes the base64 wrapper and then decompresses the gzip body' do
-        wrapped = Base64.strict_encode64(gzip(json_body))
-        expect(client.decompress_webhook_body(wrapped, 'gzip', 'base64')).to eq(json_body)
-      end
+    it 'raises WebhookSignatureError on signature mismatch' do
+      expect { client.verify_and_parse_webhook(json_body, 'definitely-wrong') }
+        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
     end
 
-    context 'unsupported encodings' do
-      %w[br brotli zstd deflate compress lz4].each do |unsupported|
-        it "rejects content_encoding=#{unsupported.inspect}" do
-          expect { client.decompress_webhook_body(json_body, unsupported, nil) }
-            .to raise_error(StreamChat::WebhookSignatureError, /unsupported webhook Content-Encoding/i)
-        end
-      end
-
-      %w[hex url binary].each do |unsupported|
-        it "rejects payload_encoding=#{unsupported.inspect}" do
-          expect { client.decompress_webhook_body(json_body, nil, unsupported) }
-            .to raise_error(StreamChat::WebhookSignatureError, /unsupported webhook payload_encoding/i)
-        end
-      end
-    end
-
-    context 'malformed payloads' do
-      it 'raises when the gzip bytes are corrupt' do
-        expect { client.decompress_webhook_body('not-actually-gzip', 'gzip', nil) }
-          .to raise_error(StreamChat::WebhookSignatureError, /failed to decompress webhook body/i)
-      end
-
-      it 'raises on invalid base64 input' do
-        expect { client.decompress_webhook_body("\x00\x01\xff not base64", nil, 'base64') }
-          .to raise_error(StreamChat::WebhookSignatureError, /payload_encoding=base64/i)
-      end
+    it 'rejects a gzip body when the signature was computed over compressed bytes' do
+      compressed = gzip(json_body)
+      sig_over_compressed = hmac_hex(api_secret, compressed)
+      expect { client.verify_and_parse_webhook(compressed, sig_over_compressed) }
+        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
     end
   end
 
-  describe '#verify_and_decode_webhook' do
-    context 'happy paths' do
-      it 'verifies and returns the body for a plain HTTP webhook' do
-        signature = hmac_hex(api_secret, json_body)
-        expect(client.verify_and_decode_webhook(json_body, signature, nil, nil)).to eq(json_body)
-      end
-
-      it 'verifies and returns the body for a gzip-compressed webhook (signature over uncompressed bytes)' do
-        compressed = gzip(json_body)
-        signature = hmac_hex(api_secret, json_body)
-        expect(client.verify_and_decode_webhook(compressed, signature, 'gzip', nil)).to eq(json_body)
-      end
-
-      it 'verifies and returns the body for a base64+gzip SQS / SNS webhook (signature over uncompressed bytes)' do
-        wrapped = Base64.strict_encode64(gzip(json_body))
-        signature = hmac_hex(api_secret, json_body)
-        expect(client.verify_and_decode_webhook(wrapped, signature, 'gzip', 'base64')).to eq(json_body)
-      end
+  describe '#verify_and_parse_sqs' do
+    it 'parses a base64-only message body' do
+      wrapped = Base64.strict_encode64(json_body)
+      sig = hmac_hex(api_secret, json_body)
+      expect(client.verify_and_parse_sqs(wrapped, sig)).to eq(event_hash)
     end
 
-    context 'signature mismatches' do
-      it 'raises WebhookSignatureError when the signature is wrong' do
-        expect { client.verify_and_decode_webhook(json_body, 'definitely-wrong', nil, nil) }
-          .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
-      end
+    it 'parses a base64 + gzip message body' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      sig = hmac_hex(api_secret, json_body)
+      expect(client.verify_and_parse_sqs(wrapped, sig)).to eq(event_hash)
+    end
 
-      it 'rejects a gzip body when the signature was computed over the compressed bytes (not the JSON)' do
-        compressed = gzip(json_body)
-        wrong_signature_over_compressed = hmac_hex(api_secret, compressed)
-        expect { client.verify_and_decode_webhook(compressed, wrong_signature_over_compressed, 'gzip', nil) }
-          .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
-      end
+    it 'rejects a wrapped body when the signature was computed over the wrapper' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      sig_over_wrapped = hmac_hex(api_secret, wrapped)
+      expect { client.verify_and_parse_sqs(wrapped, sig_over_wrapped) }
+        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+    end
+  end
 
-      it 'rejects a base64+gzip body when the signature was computed over the wrapped bytes (not the JSON)' do
-        wrapped = Base64.strict_encode64(gzip(json_body))
-        wrong_signature_over_wrapped = hmac_hex(api_secret, wrapped)
-        expect { client.verify_and_decode_webhook(wrapped, wrong_signature_over_wrapped, 'gzip', 'base64') }
-          .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
-      end
+  describe '#verify_and_parse_sns' do
+    it 'parses a base64 + gzip notification' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      sig = hmac_hex(api_secret, json_body)
+      expect(client.verify_and_parse_sns(wrapped, sig)).to eq(event_hash)
+    end
+
+    it 'returns the same event as verify_and_parse_sqs' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      sig = hmac_hex(api_secret, json_body)
+      expect(client.verify_and_parse_sns(wrapped, sig))
+        .to eq(client.verify_and_parse_sqs(wrapped, sig))
     end
   end
 end

--- a/spec/webhook_compression_spec.rb
+++ b/spec/webhook_compression_spec.rb
@@ -41,36 +41,31 @@ describe 'StreamChat webhook verification + parsing' do
 
   let(:client) { StreamChat::Client.new(api_key, api_secret) }
 
-  describe 'StreamChat::Webhook.gunzip_payload' do
+  describe 'StreamChat::Webhook.ungzip_payload' do
     it 'passes through plain bytes unchanged' do
-      expect(StreamChat::Webhook.gunzip_payload(json_body)).to eq(json_body)
+      expect(StreamChat::Webhook.ungzip_payload(json_body)).to eq(json_body)
     end
 
     it 'inflates gzip-magic bytes' do
-      expect(StreamChat::Webhook.gunzip_payload(gzip(json_body))).to eq(json_body)
+      expect(StreamChat::Webhook.ungzip_payload(gzip(json_body))).to eq(json_body)
     end
 
     it 'accepts a body provided as an array of integers' do
-      expect(StreamChat::Webhook.gunzip_payload(json_body.bytes)).to eq(json_body)
+      expect(StreamChat::Webhook.ungzip_payload(json_body.bytes)).to eq(json_body)
     end
 
     it 'returns empty input unchanged' do
-      expect(StreamChat::Webhook.gunzip_payload('')).to eq('')
+      expect(StreamChat::Webhook.ungzip_payload('')).to eq('')
     end
 
     it 'returns short input below magic length unchanged' do
-      expect(StreamChat::Webhook.gunzip_payload('ab')).to eq('ab')
+      expect(StreamChat::Webhook.ungzip_payload('ab')).to eq('ab')
     end
 
-    it 'raises InvalidWebhookError on truncated gzip with magic' do
+    it 'raises on truncated gzip with magic' do
       bad = "\x1f\x8b\x08\x00\x00\x00".b
-      expect { StreamChat::Webhook.gunzip_payload(bad) }
-        .to raise_error(StreamChat::InvalidWebhookError, /gzip decompression failed/)
-    end
-
-    it 'decompresses the helloworld fixture' do
-      expect(StreamChat::Webhook.gunzip_payload(Base64.decode64('H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA')))
-        .to eq('helloworld')
+      expect { StreamChat::Webhook.ungzip_payload(bad) }
+        .to raise_error(StreamChat::WebhookSignatureError, /decompress gzip/i)
     end
   end
 
@@ -85,18 +80,9 @@ describe 'StreamChat webhook verification + parsing' do
       expect(StreamChat::Webhook.decode_sqs_payload(wrapped)).to eq(json_body)
     end
 
-    it 'raises InvalidWebhookError on invalid base64' do
+    it 'raises on invalid base64' do
       expect { StreamChat::Webhook.decode_sqs_payload('!!!not-base64!!!') }
-        .to raise_error(StreamChat::InvalidWebhookError, /invalid base64 encoding/)
-    end
-
-    it 'decodes the helloworld base64 fixture' do
-      expect(StreamChat::Webhook.decode_sqs_payload('aGVsbG93b3JsZA==')).to eq('helloworld')
-    end
-
-    it 'decodes the helloworld base64+gzip fixture' do
-      expect(StreamChat::Webhook.decode_sqs_payload('H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA'))
-        .to eq('helloworld')
+        .to raise_error(StreamChat::WebhookSignatureError, /base64-decode/i)
     end
   end
 
@@ -121,21 +107,19 @@ describe 'StreamChat webhook verification + parsing' do
   end
 
   describe 'StreamChat::Webhook.verify_signature' do
-    it 'does not raise for a matching HMAC' do
+    it 'returns true for matching HMAC' do
       sig = hmac_hex(api_secret, json_body)
-      expect { StreamChat::Webhook.verify_signature(json_body, sig, api_secret) }.not_to raise_error
+      expect(StreamChat::Webhook.verify_signature(json_body, sig, api_secret)).to be true
     end
 
-    it 'raises InvalidWebhookError for a mismatched signature' do
-      expect { StreamChat::Webhook.verify_signature(json_body, '0' * 64, api_secret) }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
+    it 'returns false for mismatched signature' do
+      expect(StreamChat::Webhook.verify_signature(json_body, '0' * 64, api_secret)).to be false
     end
 
-    it 'raises when the signature was computed over compressed bytes' do
+    it 'rejects signatures computed over compressed bytes' do
       compressed = gzip(json_body)
       sig_over_compressed = hmac_hex(api_secret, compressed)
-      expect { StreamChat::Webhook.verify_signature(json_body, sig_over_compressed, api_secret) }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
+      expect(StreamChat::Webhook.verify_signature(json_body, sig_over_compressed, api_secret)).to be false
     end
   end
 
@@ -149,9 +133,8 @@ describe 'StreamChat webhook verification + parsing' do
         .to eq({ 'type' => 'a.future.event', 'custom' => 42 })
     end
 
-    it 'raises InvalidWebhookError on malformed JSON' do
-      expect { StreamChat::Webhook.parse_event('not json') }
-        .to raise_error(StreamChat::InvalidWebhookError, /invalid JSON payload/)
+    it 'raises on malformed JSON' do
+      expect { StreamChat::Webhook.parse_event('not json') }.to raise_error(JSON::ParserError)
     end
   end
 
@@ -182,154 +165,52 @@ describe 'StreamChat webhook verification + parsing' do
       expect(client.verify_and_parse_webhook(json_body.bytes, sig)).to eq(event_hash)
     end
 
-    it 'raises InvalidWebhookError on signature mismatch' do
+    it 'raises WebhookSignatureError on signature mismatch' do
       expect { client.verify_and_parse_webhook(json_body, 'definitely-wrong') }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
+        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
     end
 
     it 'rejects a gzip body when the signature was computed over compressed bytes' do
       compressed = gzip(json_body)
       sig_over_compressed = hmac_hex(api_secret, compressed)
       expect { client.verify_and_parse_webhook(compressed, sig_over_compressed) }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
+        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
     end
   end
 
-  describe '#verify_and_parse_sqs' do
+  describe '#parse_sqs' do
     it 'parses a base64-only message body' do
       wrapped = Base64.strict_encode64(json_body)
-      sig = hmac_hex(api_secret, json_body)
-      expect(client.verify_and_parse_sqs(wrapped, sig)).to eq(event_hash)
+      expect(client.parse_sqs(wrapped)).to eq(event_hash)
     end
 
     it 'parses a base64 + gzip message body' do
       wrapped = Base64.strict_encode64(gzip(json_body))
-      sig = hmac_hex(api_secret, json_body)
-      expect(client.verify_and_parse_sqs(wrapped, sig)).to eq(event_hash)
+      expect(client.parse_sqs(wrapped)).to eq(event_hash)
     end
 
-    it 'rejects a wrapped body when the signature was computed over the wrapper' do
+    it 'does not require a correct API secret on the client (no HMAC)' do
+      wrong_secret = StreamChat::Client.new(api_key, 'wrong-secret')
       wrapped = Base64.strict_encode64(gzip(json_body))
-      sig_over_wrapped = hmac_hex(api_secret, wrapped)
-      expect { client.verify_and_parse_sqs(wrapped, sig_over_wrapped) }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
-    end
-
-    it 'parses SQS without signature when none provided' do
-      wrapped = Base64.strict_encode64(gzip(json_body))
-      expect(client.verify_and_parse_sqs(wrapped)).to eq(event_hash)
-    end
-
-    it 'verifies and parses SQS when signature provided' do
-      wrapped = Base64.strict_encode64(gzip(json_body))
-      sig = hmac_hex(api_secret, json_body)
-      expect(client.verify_and_parse_sqs(wrapped, sig)).to eq(event_hash)
-    end
-
-    it 'parses SQS without consulting the client api_secret when no signature is requested' do
-      wrong_secret_client = StreamChat::Client.new(api_key, 'not-the-real-secret')
-      wrapped = Base64.strict_encode64(gzip(json_body))
-      expect(wrong_secret_client.verify_and_parse_sqs(wrapped)).to eq(event_hash)
+      expect(wrong_secret.parse_sqs(wrapped)).to eq(event_hash)
     end
   end
 
-  describe '#verify_and_parse_sns' do
+  describe '#parse_sns' do
     it 'parses a pre-extracted base64 + gzip notification' do
       wrapped = Base64.strict_encode64(gzip(json_body))
-      sig = hmac_hex(api_secret, json_body)
-      expect(client.verify_and_parse_sns(wrapped, sig)).to eq(event_hash)
+      expect(client.parse_sns(wrapped)).to eq(event_hash)
     end
 
-    it 'returns the same event as verify_and_parse_sqs for pre-extracted Message' do
+    it 'returns the same event as parse_sqs for pre-extracted Message' do
       wrapped = Base64.strict_encode64(gzip(json_body))
-      sig = hmac_hex(api_secret, json_body)
-      expect(client.verify_and_parse_sns(wrapped, sig))
-        .to eq(client.verify_and_parse_sqs(wrapped, sig))
+      expect(client.parse_sns(wrapped)).to eq(client.parse_sqs(wrapped))
     end
 
     it 'parses a full SNS HTTP notification envelope' do
       wrapped = Base64.strict_encode64(gzip(json_body))
       envelope = sns_envelope(wrapped)
-      sig = hmac_hex(api_secret, json_body)
-      expect(client.verify_and_parse_sns(envelope, sig)).to eq(event_hash)
-    end
-
-    it 'rejects signature computed over the envelope JSON, not the payload' do
-      wrapped = Base64.strict_encode64(gzip(json_body))
-      envelope = sns_envelope(wrapped)
-      sig_over_envelope = hmac_hex(api_secret, envelope)
-      expect { client.verify_and_parse_sns(envelope, sig_over_envelope) }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
-    end
-
-    it 'parses SNS envelope without signature when none provided' do
-      wrapped = Base64.strict_encode64(gzip(json_body))
-      envelope = sns_envelope(wrapped)
-      expect(client.verify_and_parse_sns(envelope)).to eq(event_hash)
-    end
-
-    it 'parses SNS without consulting the client api_secret when no signature is requested' do
-      wrong_secret_client = StreamChat::Client.new(api_key, 'not-the-real-secret')
-      wrapped = Base64.strict_encode64(gzip(json_body))
-      envelope = sns_envelope(wrapped)
-      expect(wrong_secret_client.verify_and_parse_sns(envelope)).to eq(event_hash)
-    end
-  end
-
-  describe 'optional-signature gating on SQS/SNS module helpers' do
-    it 'raises InvalidWebhookError when only signature is provided on SQS' do
-      wrapped = Base64.strict_encode64(json_body)
-      expect { StreamChat::Webhook.verify_and_parse_sqs(wrapped, 'a-signature', nil) }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature and secret must both be provided/)
-    end
-
-    it 'raises InvalidWebhookError when only secret is provided on SQS' do
-      wrapped = Base64.strict_encode64(json_body)
-      expect { StreamChat::Webhook.verify_and_parse_sqs(wrapped, nil, api_secret) }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature and secret must both be provided/)
-    end
-
-    it 'raises InvalidWebhookError when only signature is provided on SNS' do
-      wrapped = Base64.strict_encode64(json_body)
-      envelope = sns_envelope(wrapped)
-      expect { StreamChat::Webhook.verify_and_parse_sns(envelope, 'a-signature', nil) }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature and secret must both be provided/)
-    end
-
-    it 'raises InvalidWebhookError when only secret is provided on SNS' do
-      wrapped = Base64.strict_encode64(json_body)
-      envelope = sns_envelope(wrapped)
-      expect { StreamChat::Webhook.verify_and_parse_sns(envelope, nil, api_secret) }
-        .to raise_error(StreamChat::InvalidWebhookError, /signature and secret must both be provided/)
-    end
-
-    it 'parses SQS payload without verification when both signature and secret are nil' do
-      wrapped = Base64.strict_encode64(json_body)
-      expect(StreamChat::Webhook.verify_and_parse_sqs(wrapped)).to eq(event_hash)
-    end
-
-    it 'parses SNS payload without verification when both signature and secret are nil' do
-      wrapped = Base64.strict_encode64(gzip(json_body))
-      envelope = sns_envelope(wrapped)
-      expect(StreamChat::Webhook.verify_and_parse_sns(envelope)).to eq(event_hash)
-    end
-  end
-
-  describe 'StreamChat::InvalidWebhookError consolidation' do
-    it 'raises InvalidWebhookError on invalid base64' do
-      expect { StreamChat::Webhook.decode_sqs_payload('!!!not-base64!!!') }
-        .to raise_error(StreamChat::InvalidWebhookError, /invalid base64 encoding/)
-    end
-
-    it 'raises InvalidWebhookError on corrupt gzip' do
-      bad = "\x1f\x8b\x08\x00\x00\x00".b
-      expect { StreamChat::Webhook.gunzip_payload(bad) }
-        .to raise_error(StreamChat::InvalidWebhookError, /gzip decompression failed/)
-    end
-
-    it 'raises InvalidWebhookError on invalid JSON' do
-      expect { StreamChat::Webhook.parse_event('not json') }
-        .to raise_error(StreamChat::InvalidWebhookError, /invalid JSON payload/)
+      expect(client.parse_sns(envelope)).to eq(event_hash)
     end
   end
 end

--- a/spec/webhook_compression_spec.rb
+++ b/spec/webhook_compression_spec.rb
@@ -214,6 +214,23 @@ describe 'StreamChat webhook verification + parsing' do
       expect { client.verify_and_parse_sqs(wrapped, sig_over_wrapped) }
         .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
     end
+
+    it 'parses SQS without signature when none provided' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      expect(client.verify_and_parse_sqs(wrapped)).to eq(event_hash)
+    end
+
+    it 'verifies and parses SQS when signature provided' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      sig = hmac_hex(api_secret, json_body)
+      expect(client.verify_and_parse_sqs(wrapped, sig)).to eq(event_hash)
+    end
+
+    it 'parses SQS without consulting the client api_secret when no signature is requested' do
+      wrong_secret_client = StreamChat::Client.new(api_key, 'not-the-real-secret')
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      expect(wrong_secret_client.verify_and_parse_sqs(wrapped)).to eq(event_hash)
+    end
   end
 
   describe '#verify_and_parse_sns' do
@@ -243,6 +260,58 @@ describe 'StreamChat webhook verification + parsing' do
       sig_over_envelope = hmac_hex(api_secret, envelope)
       expect { client.verify_and_parse_sns(envelope, sig_over_envelope) }
         .to raise_error(StreamChat::InvalidWebhookError, /signature mismatch/)
+    end
+
+    it 'parses SNS envelope without signature when none provided' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      envelope = sns_envelope(wrapped)
+      expect(client.verify_and_parse_sns(envelope)).to eq(event_hash)
+    end
+
+    it 'parses SNS without consulting the client api_secret when no signature is requested' do
+      wrong_secret_client = StreamChat::Client.new(api_key, 'not-the-real-secret')
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      envelope = sns_envelope(wrapped)
+      expect(wrong_secret_client.verify_and_parse_sns(envelope)).to eq(event_hash)
+    end
+  end
+
+  describe 'optional-signature gating on SQS/SNS module helpers' do
+    it 'raises InvalidWebhookError when only signature is provided on SQS' do
+      wrapped = Base64.strict_encode64(json_body)
+      expect { StreamChat::Webhook.verify_and_parse_sqs(wrapped, 'a-signature', nil) }
+        .to raise_error(StreamChat::InvalidWebhookError, /signature and secret must both be provided/)
+    end
+
+    it 'raises InvalidWebhookError when only secret is provided on SQS' do
+      wrapped = Base64.strict_encode64(json_body)
+      expect { StreamChat::Webhook.verify_and_parse_sqs(wrapped, nil, api_secret) }
+        .to raise_error(StreamChat::InvalidWebhookError, /signature and secret must both be provided/)
+    end
+
+    it 'raises InvalidWebhookError when only signature is provided on SNS' do
+      wrapped = Base64.strict_encode64(json_body)
+      envelope = sns_envelope(wrapped)
+      expect { StreamChat::Webhook.verify_and_parse_sns(envelope, 'a-signature', nil) }
+        .to raise_error(StreamChat::InvalidWebhookError, /signature and secret must both be provided/)
+    end
+
+    it 'raises InvalidWebhookError when only secret is provided on SNS' do
+      wrapped = Base64.strict_encode64(json_body)
+      envelope = sns_envelope(wrapped)
+      expect { StreamChat::Webhook.verify_and_parse_sns(envelope, nil, api_secret) }
+        .to raise_error(StreamChat::InvalidWebhookError, /signature and secret must both be provided/)
+    end
+
+    it 'parses SQS payload without verification when both signature and secret are nil' do
+      wrapped = Base64.strict_encode64(json_body)
+      expect(StreamChat::Webhook.verify_and_parse_sqs(wrapped)).to eq(event_hash)
+    end
+
+    it 'parses SNS payload without verification when both signature and secret are nil' do
+      wrapped = Base64.strict_encode64(gzip(json_body))
+      envelope = sns_envelope(wrapped)
+      expect(StreamChat::Webhook.verify_and_parse_sns(envelope)).to eq(event_hash)
     end
   end
 

--- a/spec/webhook_compression_spec.rb
+++ b/spec/webhook_compression_spec.rb
@@ -41,31 +41,31 @@ describe 'StreamChat webhook verification + parsing' do
 
   let(:client) { StreamChat::Client.new(api_key, api_secret) }
 
-  describe 'StreamChat::Webhook.ungzip_payload' do
+  describe 'StreamChat::Webhook.gunzip_payload' do
     it 'passes through plain bytes unchanged' do
-      expect(StreamChat::Webhook.ungzip_payload(json_body)).to eq(json_body)
+      expect(StreamChat::Webhook.gunzip_payload(json_body)).to eq(json_body)
     end
 
     it 'inflates gzip-magic bytes' do
-      expect(StreamChat::Webhook.ungzip_payload(gzip(json_body))).to eq(json_body)
+      expect(StreamChat::Webhook.gunzip_payload(gzip(json_body))).to eq(json_body)
     end
 
     it 'accepts a body provided as an array of integers' do
-      expect(StreamChat::Webhook.ungzip_payload(json_body.bytes)).to eq(json_body)
+      expect(StreamChat::Webhook.gunzip_payload(json_body.bytes)).to eq(json_body)
     end
 
     it 'returns empty input unchanged' do
-      expect(StreamChat::Webhook.ungzip_payload('')).to eq('')
+      expect(StreamChat::Webhook.gunzip_payload('')).to eq('')
     end
 
     it 'returns short input below magic length unchanged' do
-      expect(StreamChat::Webhook.ungzip_payload('ab')).to eq('ab')
+      expect(StreamChat::Webhook.gunzip_payload('ab')).to eq('ab')
     end
 
     it 'raises on truncated gzip with magic' do
       bad = "\x1f\x8b\x08\x00\x00\x00".b
-      expect { StreamChat::Webhook.ungzip_payload(bad) }
-        .to raise_error(StreamChat::WebhookSignatureError, /decompress gzip/i)
+      expect { StreamChat::Webhook.gunzip_payload(bad) }
+        .to raise_error(StreamChat::InvalidWebhookError, StreamChat::InvalidWebhookError::GZIP_FAILED)
     end
   end
 
@@ -82,7 +82,7 @@ describe 'StreamChat webhook verification + parsing' do
 
     it 'raises on invalid base64' do
       expect { StreamChat::Webhook.decode_sqs_payload('!!!not-base64!!!') }
-        .to raise_error(StreamChat::WebhookSignatureError, /base64-decode/i)
+        .to raise_error(StreamChat::InvalidWebhookError, StreamChat::InvalidWebhookError::INVALID_BASE64)
     end
   end
 
@@ -133,8 +133,9 @@ describe 'StreamChat webhook verification + parsing' do
         .to eq({ 'type' => 'a.future.event', 'custom' => 42 })
     end
 
-    it 'raises on malformed JSON' do
-      expect { StreamChat::Webhook.parse_event('not json') }.to raise_error(JSON::ParserError)
+    it 'raises InvalidWebhookError on malformed JSON' do
+      expect { StreamChat::Webhook.parse_event('not json') }
+        .to raise_error(StreamChat::InvalidWebhookError, StreamChat::InvalidWebhookError::INVALID_JSON)
     end
   end
 
@@ -165,16 +166,16 @@ describe 'StreamChat webhook verification + parsing' do
       expect(client.verify_and_parse_webhook(json_body.bytes, sig)).to eq(event_hash)
     end
 
-    it 'raises WebhookSignatureError on signature mismatch' do
+    it 'raises InvalidWebhookError on signature mismatch' do
       expect { client.verify_and_parse_webhook(json_body, 'definitely-wrong') }
-        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+        .to raise_error(StreamChat::InvalidWebhookError, StreamChat::InvalidWebhookError::SIGNATURE_MISMATCH)
     end
 
     it 'rejects a gzip body when the signature was computed over compressed bytes' do
       compressed = gzip(json_body)
       sig_over_compressed = hmac_hex(api_secret, compressed)
       expect { client.verify_and_parse_webhook(compressed, sig_over_compressed) }
-        .to raise_error(StreamChat::WebhookSignatureError, 'invalid webhook signature')
+        .to raise_error(StreamChat::InvalidWebhookError, StreamChat::InvalidWebhookError::SIGNATURE_MISMATCH)
     end
   end
 


### PR DESCRIPTION
## Summary

Adds first-class support for **gzip-compressed webhook payloads** (HTTP webhooks, SQS, SNS) and exposes a stable `verify_and_parse_*` API that mirrors the cross-SDK contract published in [Webhooks Overview](https://getstream.io/chat/docs/node/webhooks_overview/#handling-the-webhook).

### New public API (`StreamChat::Webhook`)

Module-level primitives:

- `gunzip_payload(body) -> String` — gzip-magic-byte detection, no-op when not compressed
- `decode_sqs_payload(body)` — base64 decode then gunzip-if-magic
- `decode_sns_payload(notification_body)` — JSON-parse the SNS HTTP notification envelope, extract the inner `Message`, then run the SQS pipeline. Falls through to a pre-extracted `Message` string when the input is not a JSON envelope
- `verify_signature(body, signature, secret) -> bool` — HMAC-SHA256 over the **uncompressed** body, with a constant-time comparison (matters for the HTTP webhook path where the `X-Signature` header is exposed publicly; SQS / SNS deliveries arrive over AWS-internal transports where timing-attack resistance is not strictly required)
- `parse_event(payload) -> Hash` — JSON → ``Hash``

Module-level composites (return `Hash`):

- `verify_and_parse_webhook(body, signature, secret) -> Hash`
- `verify_and_parse_sqs(body, signature, secret) -> Hash`
- `verify_and_parse_sns(body, signature, secret) -> Hash`

The `StreamChat::Client` instance also exposes `verify_and_parse_webhook` / `verify_and_parse_sqs` / `verify_and_parse_sns` that use the configured `@api_secret`.

> Typed Event objects will land in Ruby in a follow-up release. Until then the helpers return the parsed JSON as a `Hash`.

### Backwards compatibility

`Client#verify_webhook` is preserved and now delegates to `StreamChat::Webhook.verify_signature`. The experimental `decompress_webhook_body` and `verify_and_decode_webhook` surfaces are removed (they were never released).

### Unified error handling

Per cross-SDK coordination (mogita's review across the 6 sibling SDK PRs), every webhook failure path now terminates at a **single exception class — `StreamChat::InvalidWebhookError`** so customers only need one `rescue` arm. The message text identifies which failure mode fired so callers that want to differentiate (security logging, retry policy) can filter on substring:

| Failure mode      | Message                       |
| ----------------- | ----------------------------- |
| Signature mismatch | `signature mismatch`         |
| Base64 decode      | `invalid base64 encoding`    |
| Gzip decompression | `gzip decompression failed`  |
| JSON parse         | `invalid JSON payload`       |

Class-level constants (`InvalidWebhookError::SIGNATURE_MISMATCH` etc.) are available for callers that prefer exact-match filtering. The legacy `Client#verify_webhook` (bool return) is untouched — it rescues the new exception internally to preserve its contract.
### Tests

`spec/webhook_compression_spec.rb` covers plain / gzip / base64 / base64+gzip payloads, signature mismatches, malformed bytes, and JSON parsing into ``Hash``. Linked Linear ticket: [CHA-3071](https://linear.app/stream/issue/CHA-3071/compress-webhook-payloads).



### Golden test fixtures (Tommaso)

Added shared reference fixtures to the test suite so future SDKs can sanity-check decoders against the same payloads:

```
aGVsbG93b3JsZA==                          -> helloworld   (base64)
H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA -> helloworld   (base64 + gzip)
```
## Test plan

- [x] `bundle exec rspec spec/webhook_compression_spec.rb` — 28 examples, 0 failures
- [x] `bundle exec rubocop` — clean on touched files




