### PR TITLE
chore(spec): per-test wall-clock timing + documentation reporter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format documentation
+--profile 25

--- a/spec/support/timing.rb
+++ b/spec/support/timing.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Per-test wall-clock timing emitted to STDOUT so CI logs surface which
+# example is in flight when a runner stalls. The default `--format
+# documentation` reporter prints test names but not timing; `--profile`
+# only summarises at the end (no help when the run hangs before reaching
+# the summary). This hook fills the gap: every example logs
+# `[timing] start ...` on enter and `[timing] N.NN s ...` on exit with
+# its full description path, so an unattended runner stuck mid-test
+# leaves a clear breadcrumb.
+RSpec.configure do |config|
+  config.before(:each) do |example|
+    example.metadata[:timing_started_at] = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    warn "[timing] start #{example.full_description}"
+  end
+
+  config.after(:each) do |example|
+    started_at = example.metadata[:timing_started_at]
+    next unless started_at
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+    status = example.exception ? 'fail' : 'pass'
+    warn format(
+      '[timing] %<elapsed>.2f s %<status>s %<description>s',
+      elapsed: elapsed,
+      status: status,
+      description: example.full_description
+    )
+  end
+end


### PR DESCRIPTION
## Summary

The default rspec progress (dots) hides which test is in flight when a runner stalls. Last week's CI on Ruby 3.4 spent **41 minutes silently** between two examples — the only thing in the transcript was `DEPRECATION update_users` messages on either side of the gap. No way to tell which spec was mid-flight without binary-searching the suite.

This PR adds two things:

1. **`.rspec` config** — `--format documentation --profile 25`. Documentation reporter prints each example name as it starts/completes; `--profile` summarises the 25 slowest examples at the end.

2. **`spec/support/timing.rb`** — `before(:each)` / `after(:each)` hook that warns to STDERR:

   ```
   [timing] start <full description>
   [timing] N.NN s <pass|fail> <full description>
   ```

   A hung runner now leaves a `start …` breadcrumb so the on-call dev can see exactly which spec is wedged. The `--profile` summary requires the run to *finish* — the per-example log handles the wedge case.

## Test plan

- [x] `bundle exec rake rubocop` — clean
- [ ] CI: confirm the new `[timing] …` lines appear in the rspec log on every Ruby matrix entry
- [ ] CI: confirm `--profile 25` summary at the bottom of the rspec output
