### PR TITLE
fix: guard StreamAPIException against empty / non-integer error bodies

### DIFF
--- a/lib/stream-chat/errors.rb
+++ b/lib/stream-chat/errors.rb
@@ -21,14 +21,28 @@ module StreamChat
     def initialize(response)
       super()
       @response = response
+
+      # Seed defaults first so the typed readers never return nil. A 5xx can
+      # arrive with an empty or non-JSON body (e.g. a load balancer emitting a
+      # bare 503), and an error envelope may omit "code"/"message" or send a
+      # non-integer "code". Without these defaults, reading error_code on such
+      # an exception raised a Sorbet TypeError that masked the real HTTP error.
+      @json_response = T.let(false, T::Boolean)
+      @error_code = T.let(-1, Integer)
+      @error_message = T.let('unknown', String)
+
       begin
         parsed_response = JSON.parse(response.body)
-        @json_response = T.let(true, T::Boolean)
-        @error_code = T.let(parsed_response.fetch('code', 'unknown'), Integer)
-        @error_message = T.let(parsed_response.fetch('message', 'unknown'), String)
       rescue JSON::ParserError
-        @json_response = false
+        return
       end
+      return unless parsed_response.is_a?(Hash)
+
+      @json_response = true
+      code = parsed_response['code']
+      @error_code = code if code.is_a?(Integer)
+      msg = parsed_response['message']
+      @error_message = msg if msg.is_a?(String)
     end
 
     sig { returns(String) }

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,68 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'stream-chat'
+
+describe StreamChat::StreamAPIException do
+  def response_with(status, body)
+    Faraday::Response.new(Faraday::Env.from(status: status, body: body))
+  end
+
+  context 'with a well-formed JSON error body' do
+    subject(:exception) do
+      described_class.new(response_with(429, { code: 9, message: 'rate limit' }.to_json))
+    end
+
+    it 'exposes the integer code and message' do
+      expect(exception.json_response).to be true
+      expect(exception.error_code).to eq(9)
+      expect(exception.error_message).to eq('rate limit')
+      expect(exception.message).to eq('StreamChat error code 9: rate limit')
+    end
+  end
+
+  context 'with a 503 and an empty body' do
+    subject(:exception) { described_class.new(response_with(503, '')) }
+
+    it 'does not raise when the typed readers are accessed' do
+      expect(exception.json_response).to be false
+      expect(exception.error_code).to eq(-1)
+      expect(exception.error_message).to eq('unknown')
+    end
+
+    it 'falls back to the HTTP status in the message' do
+      expect(exception.message).to eq('StreamChat error HTTP code: 503')
+    end
+  end
+
+  context 'with a non-JSON body' do
+    subject(:exception) { described_class.new(response_with(502, '<html>502 Bad Gateway</html>')) }
+
+    it 'falls back to defaults and the HTTP status' do
+      expect(exception.json_response).to be false
+      expect(exception.error_code).to eq(-1)
+      expect(exception.message).to eq('StreamChat error HTTP code: 502')
+    end
+  end
+
+  context 'with a non-integer code (edge rate-limit envelope)' do
+    subject(:exception) do
+      described_class.new(response_with(429, { code: 'rate_limit_exceeded', message: 'slow down' }.to_json))
+    end
+
+    it 'keeps the sentinel code rather than raising a TypeError' do
+      expect(exception.json_response).to be true
+      expect(exception.error_code).to eq(-1)
+      expect(exception.error_message).to eq('slow down')
+    end
+  end
+
+  context 'with a JSON body missing code and message' do
+    subject(:exception) { described_class.new(response_with(500, {}.to_json)) }
+
+    it 'returns the default code and message' do
+      expect(exception.error_code).to eq(-1)
+      expect(exception.error_message).to eq('unknown')
+    end
+  end
+end


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/CHA-3655

## Problem
`StreamAPIException#error_code` (`Integer`) and `#error_message` (`String`) are typed as non-nilable, but the constructor only assigned them on the JSON happy path:

```ruby
begin
  parsed_response = JSON.parse(response.body)
  @json_response = T.let(true, T::Boolean)
  @error_code = T.let(parsed_response.fetch('code', 'unknown'), Integer)
  @error_message = T.let(parsed_response.fetch('message', 'unknown'), String)
rescue JSON::ParserError
  @json_response = false   # @error_code / @error_message left unset (nil)
end
```

Two real failure modes hit this:

1. **Empty / non-JSON body (this ticket).** When the API is fronted by a load balancer that emits a bare `503` with an empty body, `JSON.parse("")` raises `JSON::ParserError`. The rescue sets `@json_response = false` but never assigns `@error_code`/`@error_message`, so they stay `nil`. The exception constructs fine, but the moment a caller reads `e.error_code` (e.g. for logging) the Sorbet `sig { returns(Integer) }` on the `attr_reader` runtime-checks the value, sees `nil`, and raises `TypeError: Expected type Integer, got NilClass (errors.rb:9)` — masking the real HTTP error.

   Reported by Homebase on `stream-chat-ruby 3.9.0`:
   ```
   TypeError: Return value: Expected type Integer, got type NilClass
     at StreamChat::StreamAPIException#error_code (errors.rb:9)
   Caused by: StreamChat::StreamAPIException: StreamChat error HTTP code: 503
   Caused by: JSON::ParserError: An empty string is not a valid JSON string
   ```

2. **Non-integer `code`.** An edge rate-limit envelope returning `code: "rate_limit_exceeded"` made `T.let(..., Integer)` raise a `TypeError` *inside* `initialize`, so callers couldn't even rescue it as a `StreamAPIException` (previously reported, ticket #80594).

## Fix
Seed both readers with sentinels (`-1` / `'unknown'`) **before** parsing, and only overwrite them when the parsed body is a `Hash` carrying values of the expected type:

- `error_code` is always an `Integer` — never `nil`, never a crash on read.
- `message()` still falls back to the HTTP status when there is no usable JSON body.
- A missing, non-integer, or non-`Hash` body no longer raises.

This fixes both failure modes at the source rather than relying on the backend to keep emitting a shape the SDK happens to tolerate.

## Tests
New network-free `spec/errors_spec.rb` covering: well-formed JSON, empty 503 body, non-JSON body, non-integer `code`, and a JSON body missing `code`/`message`.

```
6 examples, 0 failures        # bundle exec rspec spec/errors_spec.rb
2 files inspected, no offenses # bundle exec rubocop
No errors! Great job.          # bundle exec srb tc
```

## Note for reviewers
`lib/stream-chat/errors.rb` is hand-written (no codegen marker). If the intent is for SDK error types to be self-generated, the same guard should be applied in the generator template instead — flagging for that discussion.

## Checklist
- [x] Unit tests added
- [x] RuboCop + Sorbet pass
- [ ] CHANGELOG handled by standard-version on release (conventional `fix:` commit)